### PR TITLE
at extension

### DIFF
--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppData/atEppConstants.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppData/atEppConstants.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: thomasm
+ * Date: 14.09.2015
+ * Time: 14:03
+ */
+
+namespace Metaregistrar\EPP;
+
+
+class atEppConstants
+{
+    const  atExtResultNamespaceUri= "http://www.nic.at/xsd/at-ext-result-1.0";
+
+    const namespaceAtExt='http://www.nic.at/xsd/at-ext-epp-1.0';
+    const schemaLocationAtExt='http://www.nic.at/xsd/at-ext-epp-1.0 at-ext-epp-1.0.xsd';
+
+    const namespaceAtExtContact='http://www.nic.at/xsd/at-ext-contact-1.0';
+    const schemaLocationAtExtContact='http://www.nic.at/xsd/at-ext-contact-1.0 at-ext-contact-1.0.xsd';
+
+
+    const namespaceContact='urn:ietf:params:xml:ns:contact-1.0';
+    const schemaLocationContact='urn:ietf:params:xml:ns:contact-1.0 contact-1.0.xsd';
+
+    const namespaceDomain='urn:ietf:params:xml:ns:domain-1.0';
+    const schemaLocationDomain='urn:ietf:params:xml:ns:domain-1.0 domain-1.0.xsd';
+
+    const w3SchemaLocation = "http://www.w3.org/2001/XMLSchema-instance";
+
+    const autoHandle = "AUTO";
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppData/atEppContact.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppData/atEppContact.php
@@ -1,0 +1,114 @@
+<?php
+namespace Metaregistrar\EPP;
+/**
+ * The Contact Info Object
+ *
+ * This will hold the complete contact info a registry can receive and give you
+ *
+ */
+
+class atEppContact extends eppContact {
+
+
+    #
+    # These values can be set into the personType field
+    # Only NAT and JUR are allowed, ROLE default value NAT
+    # NAT (natural person) JUR (companies ect.) ROLE (e.g. administrators ect.)
+    #
+
+    const PERS_TYPE_UNSPECIFIED = 'unspecified';
+    const PERS_TYPE_PRIVATPERSON = 'privateperson';
+    const PERS_TYPE_ORGANISATION = 'organisation';
+    const PERS_TYPE_ROLE = 'role';
+
+
+
+    private $personType = self::PERS_TYPE_PRIVATPERSON;
+
+    private $whoisHidePhone=0;
+    private $whoisHideFax=0;
+    private $whoisHideEmail=0;
+
+
+
+
+    /**
+     * @param null $postalInfo
+     * @param string $personType |$personType=self::PERS_TYPE_PRIVATPERSON
+     * @param null $email
+     * @param null $voice
+     * @param null $fax
+     * @param bool|false $whoisHideEmail
+     * @param bool|false $whoisHidePhone
+     * @param bool|false $whoisHideFax
+     * @param null $password
+     * @param null $status
+     * @throws eppException
+     */
+    public function __construct($postalInfo = null,$personType=self::PERS_TYPE_UNSPECIFIED, $email = null, $voice = null, $fax = null,$whoisHideEmail=false,$whoisHidePhone=false,$whoisHideFax=false, $password = null, $status = null) {
+       parent::__construct($postalInfo , $email , $voice , $fax , $password , $status );
+       $this->setPersonType($personType);
+        $this->setWhoisHideEmail($whoisHideEmail);
+        $this->setWhoisHideFax($whoisHideFax);
+        $this->setWhoisHidePhone($whoisHidePhone);
+    }
+
+
+
+
+    private function setWhoisHidePhone($whoisHidePhone=false)
+    {
+        $this->whoisHidePhone = $whoisHidePhone ? 1 : 0;
+    }
+
+    private function setWhoisHideFax($whoisHideFax=false)
+    {
+        $this->whoisHideFax = $whoisHideFax? 1 : 0;
+    }
+
+    private function setWhoisHideEmail($whoisHideEmail=false)
+    {
+        $this->whoisHideEmail = $whoisHideEmail? 1 : 0;
+    }
+
+
+    public function getWhoisHidePhone()
+    {
+        return $this->whoisHidePhone;
+    }
+
+    public function getWhoisHideFax()
+    {
+        return $this->whoisHideFax;
+    }
+
+    public function getWhoisHideEmail()
+    {
+        return  $this->whoisHideEmail;
+    }
+
+
+    private function setPersonType($personType)
+    {
+        if($personType !== self::PERS_TYPE_ORGANISATION && $personType !== self::PERS_TYPE_PRIVATPERSON && $personType !== self::PERS_TYPE_ROLE)
+        {
+            throw new eppException('Invalid personType ' . htmlspecialchars ($personType) . ' assigned! One of the following personTypes are allowd: privateperson (natural person) organisation (companies ect.) role (e.g. administrators ect.)');
+        }
+        $this->personType=$personType;
+    }
+
+    public function getPersonType()
+    {
+        return $this->personType;
+    }
+
+
+
+    /**
+     *
+     * @return string ContactId
+     */
+    public function generateContactId() {
+        return "AUTO";
+    }
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppData/atEppContactHandle.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppData/atEppContactHandle.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: thomasm
+ * Date: 02.11.2015
+ * Time: 09:21
+ */
+
+namespace Metaregistrar\EPP;
+
+
+class atEppContactHandle extends eppContactHandle
+{
+    /**
+     * Sets the contact handle
+     * @param string $contactHandle
+     * @return void
+     */
+    public function setContactHandle($contactHandle) {
+
+        parent::setContactHandle($this->parseContactHandle($contactHandle));
+    }
+
+    /**
+     * Removes a possible -NICAT suffix, -NICAT is appended by
+     * registry automatically
+     *
+     * @param $handle
+     * @return string
+     */
+    protected function parseContactHandle($handle)
+    {
+        if(!empty($handle)) {
+            $handle = strtoupper($handle);
+            $handle = str_replace("-NICAT", "", $handle);
+        }
+        return $handle;
+    }
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppData/atEppDomain.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppData/atEppDomain.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: thomasm
+ * Date: 02.11.2015
+ * Time: 09:21
+ */
+
+namespace Metaregistrar\EPP;
+
+
+class atEppDomain extends eppDomain
+{
+    /**
+     *
+     * @param string $registrant
+     */
+    public function setRegistrant($registrant) {
+        if ($registrant instanceof eppContactHandle) {
+           parent::setRegistrant($registrant);
+        } else {
+            parent::setRegistrant($this->parseContactHandle($registrant));
+        }
+    }
+
+    /**
+     * Removes a possible -NICAT suffix, -NICAT is appended by
+     * registry automatically
+     *
+     * @param $handle
+     * @return string
+     */
+    protected function parseContactHandle($handle)
+    {
+        if(!empty($handle)) {
+            $handle = strtoupper($handle);
+            $handle = str_replace("-NICAT", "", $handle);
+        }
+        return $handle;
+    }
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppExtensions/apEppCreateContactExtension.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppExtensions/apEppCreateContactExtension.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: thomasm
+ * Date: 11.09.2015
+ * Time: 09:28
+ */
+
+namespace Metaregistrar\EPP;
+
+
+class apEppCreateContactExtension extends atEppExtensionChain
+{
+    protected $atEppContact=null;
+
+    function __construct(atEppContact $atEppContact, atEppExtensionChain $additionaEppExtension=null) {
+        if(!is_null($additionaEppExtension)) {
+            parent::__construct($additionaEppExtension);
+        }
+        $this->atEppContact = $atEppContact;
+    }
+
+
+    public function setEppRequestExtension(eppRequest $request,\DOMElement $extension)
+    {
+        $request->addExtension('xmlns:xsi', atEppConstants::w3SchemaLocation);
+
+        $contactExt_ = $request->createElement('at-ext-contact:create');
+        $contactExt_->setAttribute('xmlns:at-ext-contact', atEppConstants::namespaceAtExtContact);
+        $contactExt_->setAttribute('xsi:schemaLocation', atEppConstants::schemaLocationAtExtContact);
+        $facet_ = $request->createElement('at-ext-contact:type');
+        $facet_->appendChild(new \DOMText($this->atEppContact->getPersonType()));
+        $contactExt_->appendChild($facet_);
+        $extension->appendchild($contactExt_);
+        if(!is_null($this->additionaEppExtension))
+        {
+            $this->additionaEppExtension->setEppRequestExtension($request,$extension);
+        }
+
+
+    }
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppExtensions/apEppUpdateContactExtension.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppExtensions/apEppUpdateContactExtension.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: thomasm
+ * Date: 25.09.2015
+ * Time: 10:44
+ */
+
+namespace Metaregistrar\EPP;
+
+
+class apEppUpdateContactExtension extends atEppExtensionChain
+{
+    protected $atEppContact=null;
+
+    function __construct(atEppContact $atEppContact, atEppExtensionChain $additionaEppExtension=null) {
+        if(!is_null($additionaEppExtension)) {
+            parent::__construct($additionaEppExtension);
+        }
+        $this->atEppContact = $atEppContact;
+    }
+
+
+    public function setEppRequestExtension(eppRequest $request,\DOMElement $extension)
+    {
+        $request->addExtension('xmlns:xsi', atEppConstants::w3SchemaLocation);
+
+        $contactExt_ = $request->createElement('at-ext-contact:update');
+        $contactExt_->setAttribute('xmlns:at-ext-contact', atEppConstants::namespaceAtExtContact);
+        $contactExt_->setAttribute('xsi:schemaLocation', atEppConstants::schemaLocationAtExtContact);
+
+        $extChange_ = $request->createElement('at-ext-contact:chg');
+        $facet_ = $request->createElement('at-ext-contact:type');
+        $facet_->appendChild(new \DOMText($this->atEppContact->getPersonType()));
+        $extChange_->appendChild($facet_);
+        $contactExt_->appendChild($extChange_);
+        $extension->appendchild($contactExt_);
+        if(!is_null($this->additionaEppExtension))
+        {
+            $this->additionaEppExtension->setEppRequestExtension($request,$extension);
+        }
+
+
+    }
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppExtensions/atEppExtension.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppExtensions/atEppExtension.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Metaregistrar\EPP;
+
+/**
+ * Created by PhpStorm.
+ * User: thomasm
+ * Date: 11.09.2015
+ * Time: 09:27
+ */
+abstract class atEppExtensionChain
+{
+    protected $additionaEppExtension=null;
+
+    function __construct(atEppExtensionChain $additionaEppExtension=null) {
+
+        $this->additionaEppExtension = $additionaEppExtension;
+    }
+
+    public function setEppRequestExtension(eppRequest $request,\DOMElement $extension)
+    {
+
+
+    }
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppRequests/atEppCommandTrait.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppRequests/atEppCommandTrait.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: thomasm
+ * Date: 17.09.2015
+ * Time: 12:26
+ */
+
+namespace Metaregistrar\EPP;
+
+
+trait atEppCommandTrait
+{
+
+    protected function setAtExtensions()
+    {
+        if(!is_null($this->atEppExtensionChain)) {
+            $this->atEppExtensionChain->setEppRequestExtension($this, $this->getExtension());
+            $this->addExtension('xmlns:xsi', atEppConstants::w3SchemaLocation);
+        }
+    }
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppRequests/atEppCreateContactRequest.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppRequests/atEppCreateContactRequest.php
@@ -1,0 +1,122 @@
+<?php
+namespace Metaregistrar\EPP;
+
+class atEppCreateContactRequest extends eppCreateContactRequest {
+
+    use \Metaregistrar\EPP\atEppCommandTrait;
+
+    protected $atEppExtensionChain = null;
+
+    function __construct($createinfo,atEppExtensionChain $atEppExtensionChain=null) {
+        $this->atEppExtensionChain = $atEppExtensionChain;
+       parent::__construct($createinfo);
+       $this->addSessionId();
+
+
+    }
+
+
+
+
+    private function checkEncoding($str) {
+        return mb_check_encoding($str, 'ASCII');
+    }
+
+    public function setContact(eppContact $contact) {
+        #
+        # Object create structure
+        #
+
+        $create = $this->createElement('create');
+
+
+        $this->contactobject = $this->createElement('contact:create');
+        $this->contactobject->setAttribute('xmlns:contact',atEppConstants::namespaceContact);
+        $this->contactobject->setAttribute('xsi:schemaLocation', atEppConstants::schemaLocationContact);
+        $this->contactobject->appendChild($this->createElement('contact:id', atEppConstants::autoHandle));
+        $postalinfo = $this->createElement('contact:postalInfo');
+        $postal = $contact->getPostalInfo(0);
+        if (!$postal instanceof eppContactPostalInfo) {
+            throw new eppException('PostalInfo must be filled on eppCreateContact request');
+        }
+        if ($postal->getType()==eppContact::TYPE_AUTO) {
+            // If all fields are ascii, type = int (international) else type = loc (localization)
+            if (($this->checkEncoding($postal->getName())) && ($this->checkEncoding($postal->getOrganisationName())) && ($this->checkEncoding($postal->getStreet(0)))) {
+                $postal->setType(eppContact::TYPE_INT);
+            } else {
+                $postal->setType(eppContact::TYPE_LOC);
+            }
+        }
+        $postalinfo->setAttribute('type', $postal->getType());
+        $postalinfo->appendChild($this->createElement('contact:name', $postal->getName()));
+        if ($postal->getOrganisationName()) {
+            $postalinfo->appendChild($this->createElement('contact:org', $postal->getOrganisationName()));
+        }
+        $postaladdr = $this->createElement('contact:addr');
+        $count = $postal->getStreetCount();
+        for ($i = 0; $i < $count; $i++) {
+            $postaladdr->appendChild($this->createElement('contact:street', $postal->getStreet($i)));
+        }
+        $postaladdr->appendChild($this->createElement('contact:city', $postal->getCity()));
+        if ($postal->getProvince()) {
+            $postaladdr->appendChild($this->createElement('contact:sp', $postal->getProvince()));
+        }
+        $postaladdr->appendChild($this->createElement('contact:pc', $postal->getZipcode()));
+        $postaladdr->appendChild($this->createElement('contact:cc', $postal->getCountrycode()));
+        $postalinfo->appendChild($postaladdr);
+        $this->contactobject->appendChild($postalinfo);
+        $this->contactobject->appendChild($this->createElement('contact:voice', $contact->getVoice()));
+        if ($contact->getFax()) {
+            $this->contactobject->appendChild($this->createElement('contact:fax', $contact->getFax()));
+        }
+        $this->contactobject->appendChild($this->createElement('contact:email', $contact->getEmail()));
+        if (!is_null($contact->getPassword()))
+        {
+            $authinfo = $this->createElement('contact:authInfo');
+            $authinfo->appendChild($this->createElement('contact:pw', $contact->getPassword()));
+            $this->contactobject->appendChild($authinfo);
+        }
+        $this->setAtContactDisclosure($contact);
+        $create->appendChild($this->contactobject);
+        $this->getCommand()->appendChild($create);
+        $this->setAtExtensions();
+    }
+
+    protected function setAtContactDisclosure(atEppContact $contact)
+    {
+
+        if (!is_null($contact->getDisclose())) {
+            $disclose = $this->createElement('contact:disclose');
+            $disclose->setAttribute('flag',$contact->getDisclose());
+
+            $disclPhone = $this->createElement('contact:voice');
+            if ($contact->getDisclose()==1) {
+                $disclPhone->setAttribute('type',eppContact::TYPE_LOC);
+            }
+            if($contact->getDisclose() != $contact->getWhoisHidePhone()) {
+                $disclose->appendChild($disclPhone);
+            }
+            $disclFax = $this->createElement('contact:fax');
+            if ($contact->getDisclose()==1) {
+                $disclFax->setAttribute('type',eppContact::TYPE_LOC);
+            }
+            if($contact->getWhoisHideFax() != $contact->getDisclose()) {
+                $disclose->appendChild($disclFax);
+            }
+            $disclEmail = $this->createElement('contact:email');
+            if ($contact->getDisclose()==1) {
+                $disclEmail->setAttribute('type',eppContact::TYPE_LOC);
+            }
+            if($contact->getWhoisHideEmail() != $contact->getDisclose()) {
+                $disclose->appendChild($disclEmail);
+            }
+            $this->contactobject->appendChild($disclose);
+        }
+
+
+    }
+
+
+
+
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppRequests/atEppCreateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppRequests/atEppCreateDomainRequest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: thomasm
+ * Date: 17.09.2015
+ * Time: 09:06
+ */
+
+namespace Metaregistrar\EPP;
+
+
+class atEppCreateDomainRequest extends eppCreateDomainRequest
+{
+    use \Metaregistrar\EPP\atEppCommandTrait;
+
+    protected $atEppExtensionChain = null;
+
+    function __construct($createinfo,atEppExtensionChain $atEppExtensionChain=null) {
+        $this->atEppExtensionChain = $atEppExtensionChain;
+        parent::__construct($createinfo);
+    }
+
+
+    public function setDomain(eppDomain $domain) {
+        parent::setDomain($domain);
+        $this->setAtExtensions();
+    }
+
+
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppRequests/atEppDeleteRequest.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppRequests/atEppDeleteRequest.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: thomasm
+ * Date: 30.09.2015
+ * Time: 12:14
+ */
+
+namespace Metaregistrar\EPP;
+
+
+class atEppDeleteRequest extends eppDeleteRequest
+{
+    use \Metaregistrar\EPP\atEppCommandTrait;
+
+    protected $atEppExtensionChain = null;
+
+    function __construct($deleteinfo,atEppExtensionChain $atEppExtensionChain=null) {
+        $this->atEppExtensionChain = $atEppExtensionChain;
+        parent::__construct($deleteinfo);
+        $this->setAtExtensions();
+        $this->addSessionId();
+    }
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppRequests/atEppTransferRequest.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppRequests/atEppTransferRequest.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: thomasm
+ * Date: 02.10.2015
+ * Time: 09:52
+ */
+
+namespace Metaregistrar\EPP;
+
+
+class atEppTransferRequest extends eppTransferRequest
+{
+    use \Metaregistrar\EPP\atEppCommandTrait;
+
+    protected $atEppExtensionChain = null;
+
+    function __construct($operation, $object,atEppExtensionChain $atEppExtensionChain=null)
+    {
+        $this->atEppExtensionChain = $atEppExtensionChain;
+        parent::__construct($operation, $object);
+        $this->setAtExtensions();
+        $this->addSessionId();
+    }
+
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppRequests/atEppUpdateContactRequest.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppRequests/atEppUpdateContactRequest.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: thomasm
+ * Date: 17.09.2015
+ * Time: 14:15
+ */
+
+namespace Metaregistrar\EPP;
+
+
+class atEppUpdateContactRequest extends eppUpdateContactRequest
+{
+    use \Metaregistrar\EPP\atEppCommandTrait;
+    protected $atEppExtensionChain = null;
+
+    function __construct($objectname, $addinfo = null, $removeinfo = null,atEppContact $updateinfo = null,atEppExtensionChain $atEppExtensionChain=null) {
+        $this->atEppExtensionChain = $atEppExtensionChain;
+        parent::__construct($objectname, $addinfo , $removeinfo , $updateinfo );
+        $this->addSessionId();
+    }
+
+
+
+
+    /**
+     *
+     * @param string $contactid
+     * @param eppContact $addInfo
+     * @param eppContact $removeInfo
+     * @param eppContact $updateInfo
+     * @return \domElement
+     */
+    public function updateContact($contactid, $addInfo, $removeInfo, $updateInfo) {
+        #
+        # Object create structure
+        #
+        $update = $this->createElement('update');
+        $this->contactobject = $this->createElement('contact:update');
+        $this->contactobject->appendChild($this->createElement('contact:id', $contactid));
+        if ($updateInfo instanceof eppContact) {
+            $chgcmd = $this->createElement('contact:chg');
+            $this->addContactChanges($chgcmd, $updateInfo);
+            $this->contactobject->appendChild($chgcmd);
+        }
+        if ($removeInfo instanceof eppContact) {
+            $remcmd = $this->createElement('contact:rem');
+            $this->addContactStatus($remcmd, $removeInfo);
+            $this->contactobject->appendChild($remcmd);
+        }
+        if ($addInfo instanceof eppContact) {
+            $addcmd = $this->createElement('contact:add');
+            $this->addContactStatus($addcmd, $addInfo);
+            $this->contactobject->appendChild($addcmd);
+        }
+        $update->appendChild($this->contactobject);
+        $this->getCommand()->appendChild($update);
+        $this->setAtExtensions();
+    }
+
+    /**
+     *
+     * @param \domElement $element
+     * @param eppContact $contact
+     */
+    private function addContactStatus(\domElement $element, eppContact $contact) {
+        if ((is_array($contact->getStatus())) && (count($contact->getStatus()) > 0)) {
+            $statuses = $contact->getStatus();
+            if (is_array($statuses)) {
+                foreach ($statuses as $status) {
+                    $stat = $this->createElement('contact:status');
+                    $stat->setAttribute('s', $status);
+                    $element->appendChild($stat);
+                }
+            }
+        }
+    }
+
+
+    /**
+     *
+     * @param \domElement $element
+     * @param eppContact $contact
+     */
+    private function addContactChanges($element, eppContact $contact) {
+
+        if ($contact->getPostalInfoLength() > 0) {
+            $postal = $contact->getPostalInfo(0);
+            $postalinfo = $this->createElement('contact:postalInfo');
+            if ($postal->getType()==eppContact::TYPE_AUTO) {
+                // If all fields are ascii, type = int (international) else type = loc (localization)
+                if (($this->isAscii($postal->getName())) && ($this->isAscii($postal->getOrganisationName())) && ($this->isAscii($postal->getStreet(0)))) {
+                    $postal->setType(eppContact::TYPE_INT);
+                } else {
+                    $postal->setType(eppContact::TYPE_LOC);
+                }
+            }
+            $postalinfo->setAttribute('type', $postal->getType());
+            if (strlen($postal->getName())) {
+                $postalinfo->appendChild($this->createElement('contact:name', $postal->getName()));
+            }
+            if (strlen($postal->getOrganisationName())) {
+                $postalinfo->appendChild($this->createElement('contact:org', $postal->getOrganisationName()));
+            }
+            if ((($postal->getStreetCount()) > 0) || strlen($postal->getCity()) || strlen($postal->getProvince()) || strlen($postal->getZipcode()) || strlen($postal->getCountrycode())) {
+                $postaladdr = $this->createElement('contact:addr');
+                if (($count = $postal->getStreetCount()) > 0) {
+                    for ($i = 0; $i < $count; $i++) {
+                        $postaladdr->appendChild($this->createElement('contact:street', $postal->getStreet($i)));
+                    }
+                }
+                if (strlen($postal->getCity())) {
+                    $postaladdr->appendChild($this->createElement('contact:city', $postal->getCity()));
+                }
+                if (strlen($postal->getProvince())) {
+                    $postaladdr->appendChild($this->createElement('contact:sp', $postal->getProvince()));
+                }
+                if (strlen($postal->getZipcode())) {
+                    $postaladdr->appendChild($this->createElement('contact:pc', $postal->getZipcode()));
+                }
+                if (strlen($postal->getCountrycode())) {
+                    $postaladdr->appendChild($this->createElement('contact:cc', $postal->getCountrycode()));
+                }
+                $postalinfo->appendChild($postaladdr);
+            }
+            $element->appendChild($postalinfo);
+        }
+        if (strlen($contact->getVoice())) {
+            $element->appendChild($this->createElement('contact:voice', $contact->getVoice()));
+        }
+        if (strlen($contact->getFax())) {
+            $element->appendChild($this->createElement('contact:fax', $contact->getFax()));
+        }
+        if (strlen($contact->getEmail())) {
+            $element->appendChild($this->createElement('contact:email', $contact->getEmail()));
+        }
+        if ($contact->getPassword()) {
+            $authinfo = $this->createElement('contact:authInfo');
+            $authinfo->appendChild($this->createElement('contact:pw', $contact->getPassword()));
+            $element->appendChild($authinfo);
+        }
+        $this->setAtContactDisclosure($element,$contact);
+
+    }
+
+
+    private static function isAscii($str) {
+        return mb_check_encoding($str, 'ASCII');
+    }
+
+
+
+    protected function setAtContactDisclosure($element,atEppContact $contact)
+    {
+
+        if (!is_null($contact->getDisclose())) {
+            $disclose = $this->createElement('contact:disclose');
+            $disclose->setAttribute('flag',$contact->getDisclose());
+
+            $disclPhone = $this->createElement('contact:voice');
+            if ($contact->getDisclose()==1) {
+                $disclPhone->setAttribute('type',eppContact::TYPE_LOC);
+            }
+            if($contact->getDisclose() != $contact->getWhoisHidePhone()) {
+                $disclose->appendChild($disclPhone);
+            }
+            $disclFax = $this->createElement('contact:fax');
+            if ($contact->getDisclose()==1) {
+                $disclFax->setAttribute('type',eppContact::TYPE_LOC);
+            }
+            if($contact->getWhoisHideFax() != $contact->getDisclose()) {
+                $disclose->appendChild($disclFax);
+            }
+            $disclEmail = $this->createElement('contact:email');
+            if ($contact->getDisclose()==1) {
+                $disclEmail->setAttribute('type',eppContact::TYPE_LOC);
+            }
+            if($contact->getWhoisHideEmail() != $contact->getDisclose()) {
+                $disclose->appendChild($disclEmail);
+            }
+            $element->appendChild($disclose);
+        }
+
+
+    }
+
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppRequests/atEppUpdateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppRequests/atEppUpdateDomainRequest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: thomasm
+ * Date: 17.09.2015
+ * Time: 14:03
+ */
+
+namespace Metaregistrar\EPP;
+
+
+class atEppUpdateDomainRequest extends eppUpdateDomainRequest
+{
+    use \Metaregistrar\EPP\atEppCommandTrait;
+
+    protected $atEppExtensionChain = null;
+
+    function __construct($objectname, $addinfo = null, $removeinfo = null, $updateinfo = null, $forcehostattr=false,atEppExtensionChain $atEppExtensionChain=null) {
+        $this->atEppExtensionChain = $atEppExtensionChain;
+        parent::__construct($objectname, $addinfo , $removeinfo , $updateinfo , $forcehostattr);
+        $this->addSessionId();
+
+    }
+
+    public function updateDomain($domainname, $addInfo, $removeInfo, $updateInfo) {
+        parent::updateDomain($domainname, $addInfo, $removeInfo, $updateInfo);
+        $this->setAtExtensions();
+    }
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppResponses/atEppCreateResponse.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppResponses/atEppCreateResponse.php
@@ -1,0 +1,23 @@
+<?php
+namespace Metaregistrar\EPP;
+
+class atEppCreateResponse extends eppCreateResponse {
+
+    use \Metaregistrar\EPP\atEppResponseTrait;
+
+
+    /**
+     * add -NICAT suffix
+     *
+     *
+     * @return string contact_id
+     */
+    public function getContactId() {
+        $result=parent::getContactId();
+        if(!is_null($result))
+        {
+            $result .= "-NICAT";
+        }
+        return $result;
+    }
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppResponses/atEppDeleteResponse.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppResponses/atEppDeleteResponse.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: thomasm
+ * Date: 30.09.2015
+ * Time: 12:14
+ */
+
+namespace Metaregistrar\EPP;
+
+
+class atEppDeleteResponse extends eppDeleteResponse
+{
+    use \Metaregistrar\EPP\atEppResponseTrait;
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppResponses/atEppResponseTrait.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppResponses/atEppResponseTrait.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: thomasm
+ * Date: 14.09.2015
+ * Time: 11:05
+ */
+
+namespace Metaregistrar\EPP;
+
+
+trait atEppResponseTrait
+{
+    /**
+     *
+     * @return string client ticket request id
+     */
+    public function getClTrId() {
+
+        $xpath = $this->xPath();
+        $result = $xpath->query("/epp:epp/epp:response/epp:trID/epp:clTRID");
+
+        if (is_object($result) && ($result->length > 0)) {
+            return trim($result->item(0)->nodeValue);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     *
+     * @return string server ticket request id
+     */
+    public function getSvTrId() {
+        $xpath = $this->xPath();
+        $result = $xpath->query("/epp:epp/epp:response/epp:trID/epp:svTRID");
+        if (is_object($result) && ($result->length > 0)) {
+            return trim($result->item(0)->nodeValue);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     *
+     * @return array
+     */
+    public function getExtensionResult() {
+        $xpath = $this->xPath();
+        $xpath->registerNamespace ( "at-ext" , atEppConstants::atExtResultNamespaceUri );
+
+        $result = $this->getXPathExtension($xpath);
+
+        if (is_object($result) && ($result->length > 0)) {
+            $resultList=[];
+            for($i=0;$i < $result->length;$i++) {
+                $xpathExtensionIndex = $i+1;
+                $code_ = $this->getExtensionResultCode($xpathExtensionIndex);
+                  $resultList[] =
+                ['code' => $code_,'severity' => $this->getExtensionResultSeverity($xpathExtensionIndex),
+                'message' => $this->getExtensionResultMessage($xpathExtensionIndex), 'details' =>  $this->getExtensionResultDetails($xpathExtensionIndex)];
+            }
+            return $resultList;
+        } else {
+            return null;
+        }
+    }
+
+    private function getXPathExtension($xpath)
+    {
+        $xpath = $this->xPath();
+        $xpath->registerNamespace ( "at-ext" , atEppConstants::atExtResultNamespaceUri );
+        $result = $xpath->query('/epp:epp/epp:response/epp:extension/at-ext:conditions/at-ext:condition');
+
+        if (!is_object($result) || ($result->length == 0)) {
+            $result = $xpath->query('/epp:epp/epp:response/epp:msgq/epp:extension/at-ext:conditions/at-ext:condition');
+        }
+        return $result;
+
+    }
+
+
+    /**
+     *
+     * @return string extension result code
+     */
+    public function getExtensionResultCode($xpathExtensionIndex=1) {
+        $xpath = $this->xPath();
+        $xpath->registerNamespace ( "at-ext" , atEppConstants::atExtResultNamespaceUri );
+        $result = $xpath->query('/epp:epp/epp:response/epp:extension/at-ext:conditions/at-ext:condition[' . $xpathExtensionIndex . ']/@code');
+
+        if (is_object($result) && ($result->length > 0)) {
+            return trim($result->item(0)->nodeValue);
+        } else {
+            $result = $xpath->query('/epp:epp/epp:response/epp:msgq/epp:extension/at-ext:conditions/at-ext:condition[' . $xpathExtensionIndex . ']/@code');
+            if (is_object($result) && ($result->length > 0)) {
+                return trim($result->item(0)->nodeValue);
+            }
+        }
+        return null;
+    }
+
+
+
+    /**
+     *
+     * @return string extension result severity
+     */
+    public function getExtensionResultSeverity($xpathExtensionIndex=1) {
+        $xpath = $this->xPath();
+        $xpath->registerNamespace ( "at-ext" , atEppConstants::atExtResultNamespaceUri );
+        $result = $xpath->query('/epp:epp/epp:response/epp:extension/at-ext:conditions/at-ext:condition[' . $xpathExtensionIndex . ']/@severity');
+        if (is_object($result) && ($result->length > 0)) {
+            return trim($result->item(0)->nodeValue);
+        } else {
+            $result = $xpath->query('/epp:epp/epp:response/epp:msgq/epp:extension/at-ext:conditions/at-ext:condition[' . $xpathExtensionIndex . ']/@severity');
+            if (is_object($result) && ($result->length > 0)) {
+                return trim($result->item(0)->nodeValue);
+            }
+        }
+        return null;
+    }
+
+    /**
+     *
+     * @return string extension result severity
+     */
+    public function getExtensionResultMessage($xpathExtensionIndex=1) {
+        $xpath = $this->xPath();
+        $xpath->registerNamespace ( "at-ext" , atEppConstants::atExtResultNamespaceUri );
+        $result = $xpath->query('/epp:epp/epp:response/epp:extension/at-ext:conditions/at-ext:condition[' . $xpathExtensionIndex . ']/at-ext:msg');
+        if (is_object($result) && ($result->length > 0)) {
+            return trim($result->item(0)->nodeValue);
+        } else {
+            $result = $xpath->query('/epp:epp/epp:response/epp:msgq/epp:extension/at-ext:conditions/at-ext:condition[' . $xpathExtensionIndex . ']/at-ext:msg');
+            if (is_object($result) && ($result->length > 0)) {
+                return trim($result->item(0)->nodeValue);
+            } else {
+                return null;
+            }
+        }
+    }
+
+    /**
+     *
+     * @return string extension result severity
+     */
+    public function getExtensionResultDetails($xpathExtensionIndex=1) {
+        $xpath = $this->xPath();
+        $xpath->registerNamespace ( "at-ext" , atEppConstants::atExtResultNamespaceUri );
+        $result = $xpath->query('/epp:epp/epp:response/epp:extension/at-ext:conditions/at-ext:condition[' . $xpathExtensionIndex . ']/at-ext:details');
+        if (is_object($result) && ($result->length > 0)) {
+            return trim($result->item(0)->nodeValue);
+        } else {
+            $result = $xpath->query('/epp:epp/epp:response/epp:msgq/epp:extension/at-ext:conditions/at-ext:condition[' . $xpathExtensionIndex . ']/at-ext:details');
+            if (is_object($result) && ($result->length > 0)) {
+                return trim($result->item(0)->nodeValue);
+            } else {
+                return null;
+            }
+        }
+    }
+
+
+    /**
+     *
+     * @return string result created domain
+     */
+    public function getDomainCreated() {
+        $xpath = $this->xPath();
+        $result = $xpath->query('/epp:epp/epp:response/epp:resData/domain:creData/domain:name');
+        if (is_object($result) && ($result->length > 0)) {
+            return trim($result->item(0)->nodeValue);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     *
+     * @return string result create date
+     */
+    public function getDomainCreateDate() {
+        $xpath = $this->xPath();
+        $result = $xpath->query('/epp:epp/epp:response/epp:resData/domain:creData/domain:crDate');
+        if (is_object($result) && ($result->length > 0)) {
+            return trim($result->item(0)->nodeValue);
+        } else {
+            return null;
+        }
+    }
+
+
+    public function Success() {
+        $resultcode = $this->getResultCode();
+        $success = ($resultcode{0} == '1');
+        if (!$success) {
+            switch ($resultcode{1}) {
+                case '0':
+                    $this->setProblemtype('syntax');
+                    break;
+                case '1':
+                    $this->setProblemtype('implementation-specific');
+                    break;
+                case '2':
+                    $this->setProblemtype('security');
+                    break;
+                case '3':
+                    $this->setProblemtype('data management');
+                    break;
+                case '4':
+                    $this->setProblemtype('server system');
+                    break;
+                case '5':
+                    $this->setProblemtype('connection management');
+                    break;
+            }
+            $resultmessage = $this->getResultMessage();
+
+            $errorstring = "Error $resultcode: $resultmessage";
+            $id = null;
+            $value = $this->getResultValue();
+            if ($value) {
+                $id = 'value:' . $value;
+            }
+            $resultcontactid = $this->getResultContactId();
+            if ($resultcontactid) {
+                $id = 'contactid:' . $resultcontactid;
+            }
+            $resulthostname = $this->getResultHostName();
+            if ($resulthostname) {
+                $id = 'hostname:' . $resulthostname;
+            }
+            $resultdomainname = $this->getResultDomainName();
+            if ($resultdomainname) {
+                $id = 'domainname:' . $resultdomainname;
+            }
+            $resultstatus = $this->getResultHostStatus();
+            if ($resultstatus) {
+                $id = 'status:' . $resultstatus;
+            }
+            $resultaddr = $this->getResultHostAddr();
+            if ($resultaddr) {
+                $id = 'hostaddr:' . $resultaddr;
+            }
+            if ($id) {
+                $errorstring .= '; ' . $id;
+            }
+            $resultreason = $this->getResultReason();
+            if (strlen($resultreason)) {
+                $errorstring .= ' (' . $resultreason . ')';
+            }
+
+            $extendedReason_ = json_encode($this->getExtensionResult());
+
+            throw new eppException($errorstring, $resultcode, null, $extendedReason_, $id);
+        } else {
+            return true;
+        }
+    }
+
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppResponses/atEppTransferResponse.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppResponses/atEppTransferResponse.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: thomasm
+ * Date: 02.10.2015
+ * Time: 09:56
+ */
+
+namespace Metaregistrar\EPP;
+
+
+class atEppTransferResponse extends eppTransferResponse
+{
+    use \Metaregistrar\EPP\atEppResponseTrait;
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppResponses/atEppUpdateContactResponse.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppResponses/atEppUpdateContactResponse.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: thomasm
+ * Date: 17.09.2015
+ * Time: 14:47
+ */
+
+namespace Metaregistrar\EPP;
+
+
+class atEppUpdateContactResponse extends eppUpdateContactResponse
+{
+    use \Metaregistrar\EPP\atEppResponseTrait;
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppResponses/atEppUpdateDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppResponses/atEppUpdateDomainResponse.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: thomasm
+ * Date: 17.09.2015
+ * Time: 14:48
+ */
+
+namespace Metaregistrar\EPP;
+
+
+class atEppUpdateDomainResponse extends eppUpdateDomainResponse
+{
+    use \Metaregistrar\EPP\atEppResponseTrait;
+}

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/includes.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/includes.php
@@ -1,0 +1,9 @@
+<?php
+
+include_once(dirname(__FILE__) . '/eppRequests/atEppCreateContactRequest.php');
+include_once(dirname(__FILE__) . '/eppRequests/atEppUpdateContactRequest.php');
+include_once(dirname(__FILE__) . '/eppRequests/atEppCreateDomainRequest.php');
+include_once(dirname(__FILE__) . '/eppRequests/atEppUpdateDomainRequest.php');
+include_once(dirname(__FILE__) . '/eppResponses/atEppCreateResponse.php');
+include_once(dirname(__FILE__) . '/eppResponses/atEppUpdateContactResponse.php');
+include_once(dirname(__FILE__) . '/eppResponses/atEppUpdateDomainResponse.php');

--- a/Registries/nicatEppConnection/atEppConnection/atEppConnection.php
+++ b/Registries/nicatEppConnection/atEppConnection/atEppConnection.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Metaregistrar\EPP;
+/**
+ * Created by PhpStorm.
+ * User: thomasm
+ * Date: 09.09.2015
+ * Time: 10:56
+ */
+class atEppConnection extends nicatEppConnection {
+
+    /*
+    |--------------------------------------------------------------------------
+    | atEppConnection
+    |--------------------------------------------------------------------------
+    |
+    | Epp connection for TLD .at
+    |
+    */
+
+    public function __construct($logging = false, $settingsfile = null) {
+        parent::__construct($logging, $settingsfile);
+        parent::setServices(array('urn:ietf:params:xml:ns:domain-1.0' => 'domain', 'urn:ietf:params:xml:ns:contact-1.0' => 'contact'));
+        parent::enableDnssec();
+        parent::addExtension('at-ext-epp', atEppConstants::namespaceAtExt);
+
+        parent::addCommandResponse('Metaregistrar\EPP\atEppCreateContactRequest', 'Metaregistrar\EPP\atEppCreateResponse');
+        parent::addCommandResponse('Metaregistrar\EPP\atEppUpdateContactRequest', 'Metaregistrar\EPP\atEppUpdateContactResponse');
+        parent::addCommandResponse('Metaregistrar\EPP\atEppCreateDomainRequest', 'Metaregistrar\EPP\atEppCreateResponse');
+        parent::addCommandResponse('Metaregistrar\EPP\atEppUpdateDomainRequest', 'Metaregistrar\EPP\atEppUpdateDomainResponse');
+        parent::addCommandResponse('Metaregistrar\EPP\atEppDeleteRequest', 'Metaregistrar\EPP\atEppDeleteResponse');
+        parent::addCommandResponse('Metaregistrar\EPP\atEppTransferRequest', 'Metaregistrar\EPP\atEppTransferResponse');
+    }
+
+
+
+
+
+}

--- a/Registries/nicatEppConnection/nicatEppConnection.php
+++ b/Registries/nicatEppConnection/nicatEppConnection.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Metaregistrar\EPP;
+/**
+ * Created by PhpStorm.
+ * User: thomasm
+ * Date: 23.09.2015
+ * Time: 13:51
+ */
+abstract class nicatEppConnection extends eppConnection
+{
+    /*
+    |--------------------------------------------------------------------------
+    | nicatEppConnection
+    |--------------------------------------------------------------------------
+    |
+    | Is a general eppConnection parent class for all upcomming registry extensions
+    | provided by Nic.at GmbH.
+    |
+    */
+
+    private $doPeerVerification=true;
+
+    /**
+     * Wraps epp login, this function wrapper makes it easier to unittest the different
+     * epp commands using mockery objects
+     *
+     * @return bool
+     * @throws eppException
+     */
+    public function doLogin()
+    {
+        $login = new eppLoginRequest;
+        if ((($response = $this->writeandread($login)) instanceof eppLoginResponse) && ($response->Success())) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Disable Peer Verification for e.g. testing purposes
+     *
+     * @param bool|true $verifyPeer
+     */
+    public function setVerifyPeer($verifyPeer=true)
+    {
+        $this->doPeerVerification = $verifyPeer;
+    }
+
+
+    /**
+     * Connect to the address and port fsockopen replaces by general stream_socket_client
+     * @param string $address
+     * @param int $port
+     * @return boolean
+     */
+    public function connect($hostname = null, $port = null) {
+        if ($hostname) {
+            $this->hostname = $hostname;
+        }
+        if ($port) {
+            $this->port = $port;
+        }
+        if ($this->local_cert_path) {
+            parent::connect($hostname,$port);
+        } else {
+            //We don't want our error handler to kick in at this point...
+
+            $target = $this->hostname . ":" . $this->port;
+            $errno = '';
+            $errstr = '';
+            putenv('SURPRESS_ERROR_HANDLER=1');
+            $context = stream_context_create();
+            if(!$this->doPeerVerification) {
+                stream_context_set_option($context, 'ssl', 'verify_peer', false);
+                stream_context_set_option($context, 'ssl', 'verify_peer_name', false);
+            }
+            $this->connection = stream_socket_client($target, $errno, $errstr, $this->timeout, STREAM_CLIENT_CONNECT, $context);
+            putenv('SURPRESS_ERROR_HANDLER=0');
+            if (is_resource($this->connection)) {
+                $this->writeLog("Connection made","CONNECT");
+                stream_set_blocking($this->connection, false);
+                stream_set_timeout($this->connection, $this->timeout);
+                if ($errno == 0) {
+                    $this->read();
+                    return true;
+                } else {
+                    return false;
+                }
+            } else {
+                $this->writeLog("Connection could not be opened: $errno $errstr","ERROR");
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Extension for .at provided by the Austrian Registry nic.at GmbH

so far this extension provides the most important commands
contact create/update/delete
domain update/create
domain transfer 


in general at uses an extended namespace for contact-transactions: http://www.nic.at/xsd/at-ext-contact-1.0
you can retrieve  extended result data using: http://www.nic.at/xsd/at-ext-result-1.0
by now .at does not have host-object related transactions. 

still missing command: withdraw: http://www.nic.at/xsd/at-ext-epp-1.0 will be implemented as soon as possible


nic.at GmbH
Jakob-Haringer-Str. 8/V
5020 Salzburg, Austria
Tel: +43 662 46 69
Fax: +43 662 46 69-19
Web: http://www.nic.at
E-Mail: thomas.meike@nic.at

