### PR TITLE
eppContactPostalInfo name and organisation are never null

### DIFF
--- a/Protocols/EPP/eppRequests/eppUpdateContactRequest.php
+++ b/Protocols/EPP/eppRequests/eppUpdateContactRequest.php
@@ -99,10 +99,10 @@ class eppUpdateContactRequest extends eppRequest {
                 }
             }
             $postalinfo->setAttribute('type', $postal->getType());
-            if (!is_null($postal->getName())) {
+            if (!is_null($postal->getName())  && !$postal->getName()=='') {
                 $postalinfo->appendChild($this->createElement('contact:name', $postal->getName()));
             }
-            if (!is_null($postal->getOrganisationName())) {
+            if (!is_null($postal->getOrganisationName()) && !$postal->getOrganisationName()=='') {
                 $postalinfo->appendChild($this->createElement('contact:org', $postal->getOrganisationName()));
             }
             if ((($postal->getStreetCount()) > 0) || strlen($postal->getCity()) || strlen($postal->getProvince()) || strlen($postal->getZipcode()) || strlen($postal->getCountrycode())) {

--- a/Protocols/EPP/eppRequests/eppUpdateContactRequest.php
+++ b/Protocols/EPP/eppRequests/eppUpdateContactRequest.php
@@ -99,10 +99,10 @@ class eppUpdateContactRequest extends eppRequest {
                 }
             }
             $postalinfo->setAttribute('type', $postal->getType());
-            if (!is_null($postal->getName())  && !$postal->getName()=='') {
+            if (!$postal->getName()=='') {
                 $postalinfo->appendChild($this->createElement('contact:name', $postal->getName()));
             }
-            if (!is_null($postal->getOrganisationName()) && !$postal->getOrganisationName()=='') {
+            if (!$postal->getOrganisationName()=='') {
                 $postalinfo->appendChild($this->createElement('contact:org', $postal->getOrganisationName()));
             }
             if ((($postal->getStreetCount()) > 0) || strlen($postal->getCity()) || strlen($postal->getProvince()) || strlen($postal->getZipcode()) || strlen($postal->getCountrycode())) {


### PR DESCRIPTION
I am sure that getName and getOrganisationName in eppContactPostalInfo.php never return null, but empty string, since the setName and setOrganisationName use htmlspecialchars which returns and empty string if null is passed as a parameter.