### PR TITLE
Method loadXML is not compatible with the domdocument method. 

### DIFF
--- a/Protocols/EPP/eppExtensions/command-ext-1.0/eppResponses/metaregSudoResponse.php
+++ b/Protocols/EPP/eppExtensions/command-ext-1.0/eppResponses/metaregSudoResponse.php
@@ -2,7 +2,8 @@
 
 namespace Metaregistrar\EPP;
 
-class metaregSudoResponse extends eppResponse {
+class metaregSudoResponse extends eppResponse
+{
 
     /**
      * @var eppResponse
@@ -13,7 +14,8 @@ class metaregSudoResponse extends eppResponse {
      * metaregSudoResponse constructor.
      * @param metaregSudoRequest $originalrequest
      */
-    function __construct(metaregSudoRequest $originalrequest) {
+    function __construct(metaregSudoRequest $originalrequest)
+    {
         parent::__construct($originalrequest);
         $tmpConn = new eppConnection;
         $this->originalResponse = $tmpConn->createResponse($originalrequest->getOriginalRequest());
@@ -21,11 +23,12 @@ class metaregSudoResponse extends eppResponse {
 
     function loadXML($xml, $options = NULL)
     {
-        $this->originalResponse->loadXML($xml);
+        $this->originalResponse->loadXML($xml, $options);
         return parent::loadXML($xml);
     }
-    
-    function getOriginalResponse() {
+
+    function getOriginalResponse()
+    {
         return $this->originalResponse;
     }
 }

--- a/Protocols/EPP/eppExtensions/command-ext-1.0/eppResponses/metaregSudoResponse.php
+++ b/Protocols/EPP/eppExtensions/command-ext-1.0/eppResponses/metaregSudoResponse.php
@@ -2,9 +2,12 @@
 
 namespace Metaregistrar\EPP;
 
+/**
+ * Class metaregSudoResponse
+ * @package Metaregistrar\EPP
+ */
 class metaregSudoResponse extends eppResponse
 {
-
     /**
      * @var eppResponse
      */
@@ -12,21 +15,30 @@ class metaregSudoResponse extends eppResponse
 
     /**
      * metaregSudoResponse constructor.
+     *
      * @param metaregSudoRequest $originalrequest
      */
     function __construct(metaregSudoRequest $originalrequest)
     {
         parent::__construct($originalrequest);
         $tmpConn = new eppConnection;
-        $this->originalResponse = $tmpConn->createResponse($originalrequest->getOriginalRequest());
+        $this->originalResponse = $tmpConn->createResponse(
+            $originalrequest->getOriginalRequest()
+        );
     }
 
+    /**
+     * @inheritdoc
+     */
     function loadXML($xml, $options = NULL)
     {
         $this->originalResponse->loadXML($xml, $options);
         return parent::loadXML($xml);
     }
 
+    /**
+     * @return eppResponse
+     */
     function getOriginalResponse()
     {
         return $this->originalResponse;

--- a/Protocols/EPP/eppExtensions/command-ext-1.0/eppResponses/metaregSudoResponse.php
+++ b/Protocols/EPP/eppExtensions/command-ext-1.0/eppResponses/metaregSudoResponse.php
@@ -4,20 +4,23 @@ namespace Metaregistrar\EPP;
 
 class metaregSudoResponse extends eppResponse {
 
+    /**
+     * @var eppResponse
+     */
     private $originalResponse;
 
-    function __construct($originalrequest) {
+    /**
+     * metaregSudoResponse constructor.
+     * @param metaregSudoRequest $originalrequest
+     */
+    function __construct(metaregSudoRequest $originalrequest) {
         parent::__construct($originalrequest);
-        /* @var originalrequest Metaregistrar\EPP\metaregSudoRequest */
-        $testconn = new eppConnection;
-        foreach ($testconn->getResponses() as $req => $res) {
-            if ($originalrequest->getOriginalRequest() instanceof $req) {
-                $this->originalResponse = new $res();
-            }
-        }
+        $tmpConn = new eppConnection;
+        $this->originalResponse = $tmpConn->createResponse($originalrequest->getOriginalRequest());
     }
-    
-    function loadXML($xml) {
+
+    function loadXML($xml, $options = NULL)
+    {
         $this->originalResponse->loadXML($xml);
         return parent::loadXML($xml);
     }


### PR DESCRIPTION
This was giving errors in our php version. Also fixed the constructor to be less duplicate code. Please run the unittests before merging. Also cleaned up some code.