### PR TITLE
Make error handling more consistent for connect()

### DIFF
--- a/Protocols/EPP/eppConnection.php
+++ b/Protocols/EPP/eppConnection.php
@@ -366,7 +366,8 @@ class eppConnection {
                 $this->read();
                 return true;
             } else {
-                throw new eppException("Error connecting to $target: $errstr (code $errno)",$errno,null,$errstr);
+            	$this->writeLog("Connection could not be opened to $target: $errno $errstr","ERROR");
+                return false;
             }
         } else {
             //We don't want our error handler to kick in at this point...
@@ -390,7 +391,7 @@ class eppConnection {
                     return false;
                 }
             } else {
-                $this->writeLog("Connection could not be opened: $errno $errstr","ERROR");
+                $this->writeLog("Connection could not be opened to $target: $errno $errstr","ERROR");
                 return false;
             }
         }


### PR DESCRIPTION
SSL vs. no-SSL connection failures are handled differently. This change makes them behave the same way: do not throw eppException but write to log and return false. This was the behavior for no-SSL connections before.