### PR TITLE
Rename getLegalEmail to getContactLegalEmail to improve consistency.

### DIFF
--- a/Protocols/EPP/eppExtensions/ficora/eppResponses/ficoraEppInfoContactResponse.php
+++ b/Protocols/EPP/eppExtensions/ficora/eppResponses/ficoraEppInfoContactResponse.php
@@ -44,7 +44,7 @@ class ficoraEppInfoContactResponse extends eppInfoContactResponse {
      *
      * @return string|null legalemail
      */
-    public function getLegalEmail()
+    public function getContactLegalEmail()
     {
         return $this->getXpathQueryResult('/epp:epp/epp:response/epp:resData/contact:infData/contact:legalemail');
     }

--- a/Tests/ficoraEppInfoContactTest.php
+++ b/Tests/ficoraEppInfoContactTest.php
@@ -68,7 +68,7 @@ class ficoraEppInfoContactTest extends eppTestCase {
         $contactResponse = $this->getFicoraContactResponse();
         $this->assertEquals($contactResponse->getContactRole(), 5);
         $this->assertEquals($contactResponse->getContactType(), 0);
-        $this->assertEquals($contactResponse->getLegalEmail(), 'legal@mail.mail');
+        $this->assertEquals($contactResponse->getContactLegalEmail(), 'legal@mail.mail');
 
         $contacts = $contactResponse->getContactPostalInfo();
         $this->assertCount(1, $contacts);


### PR DESCRIPTION
As the title says.