### PR TITLE
Add support for registrant changes for *.fi domains, minor fixes

### DIFF
--- a/Protocols/EPP/eppExtensions/ficora/eppData/ficoraEppDomain.php
+++ b/Protocols/EPP/eppExtensions/ficora/eppData/ficoraEppDomain.php
@@ -1,0 +1,40 @@
+<?php
+namespace Metaregistrar\EPP;
+
+class ficoraEppDomain extends eppDomain {
+
+    const REGISTRANT_TRANSFER_CODE_NEW = 'new';
+
+    /**
+     * Domain registrant transfer code
+     * @var string
+     */
+    private $registrantTransferCode = '';
+
+    /**
+     *
+     * @param eppContact $registrant
+     * @param string $authorisationCode
+     */
+
+    public function __construct($domainname, $registrant = null, $contacts = null, $hosts = null, $period = 0, $authorisationCode = null) {
+        parent::__construct($domainname, $registrant, $contacts, $hosts, $period, $authorisationCode);
+    }
+
+    /**
+     * Sets the registrant transfer code. Set to "new" (or any other value) and do not do any other changes to request a new transfer code to be sent to domain registrant via email.
+     * @param string $registrantTransferCode
+     */
+    public function setRegistrantTransferCode($registrantTransferCode)
+    {
+        $this->registrantTransferCode = $registrantTransferCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRegistrantTransferCode()
+    {
+        return $this->registrantTransferCode;
+    }
+}

--- a/Protocols/EPP/eppExtensions/ficora/eppData/ficoraEppDomain.php
+++ b/Protocols/EPP/eppExtensions/ficora/eppData/ficoraEppDomain.php
@@ -3,8 +3,6 @@ namespace Metaregistrar\EPP;
 
 class ficoraEppDomain extends eppDomain {
 
-    const REGISTRANT_TRANSFER_CODE_NEW = 'new';
-
     /**
      * Domain registrant transfer code
      * @var string
@@ -12,17 +10,7 @@ class ficoraEppDomain extends eppDomain {
     private $registrantTransferCode = '';
 
     /**
-     *
-     * @param eppContact $registrant
-     * @param string $authorisationCode
-     */
-
-    public function __construct($domainname, $registrant = null, $contacts = null, $hosts = null, $period = 0, $authorisationCode = null) {
-        parent::__construct($domainname, $registrant, $contacts, $hosts, $period, $authorisationCode);
-    }
-
-    /**
-     * Sets the registrant transfer code. Set to "new" (or any other value) and do not do any other changes to request a new transfer code to be sent to domain registrant via email.
+     * Sets the registrant transfer code. Set to any value (and do not do any other changes to domain) to request a new transfer code to be sent to domain registrant via email.
      * @param string $registrantTransferCode
      */
     public function setRegistrantTransferCode($registrantTransferCode)

--- a/Protocols/EPP/eppExtensions/ficora/eppRequests/ficoraEppUpdateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/ficora/eppRequests/ficoraEppUpdateDomainRequest.php
@@ -43,11 +43,11 @@ class ficoraEppUpdateDomainRequest extends eppUpdateDomainRequest {
                 $this->addDomainContact($element, $contact->getContactHandle(), $contact->getContactType());
             }
         }
+
+        // Changing status is not supported for *.fi domains, verified from registry
         $statuses = $domain->getStatuses();
-        if (is_array($statuses)) {
-            foreach ($statuses as $status) {
-                $this->addDomainStatus($element, $status);
-            }
+        if (is_array($statuses) && count($statuses)) {
+            throw new eppException('Changing statuses is not supported for *.fi domains.');
         }
 
         // authinfo might contain domain:pw (provider transfer key) and/or domain:pwregistranttransfer (registrant transfer key)
@@ -58,10 +58,13 @@ class ficoraEppUpdateDomainRequest extends eppUpdateDomainRequest {
                 $pw = $this->createElement('domain:pw');
                 $pw->appendChild($this->createCDATASection($domain->getAuthorisationCode()));
                 $authinfo->appendChild($pw);
-            } else if ($domain->getRegistrant() || $domain->getRegistrantTransferCode()) {
+            }
+
+            if ($domain->getRegistrant() || $domain->getRegistrantTransferCode()) {
                 $registrantPassword = $this->createElement('domain:pwregistranttransfer', $domain->getRegistrantTransferCode());
                 $authinfo->appendChild($registrantPassword);
             }
+
             $element->appendChild($authinfo);
         }
     }

--- a/Protocols/EPP/eppExtensions/ficora/eppRequests/ficoraEppUpdateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/ficora/eppRequests/ficoraEppUpdateDomainRequest.php
@@ -1,0 +1,68 @@
+<?php
+namespace Metaregistrar\EPP;
+
+class ficoraEppUpdateDomainRequest extends eppUpdateDomainRequest {
+
+    // Note: default value for $namespacesinroot differs from parent
+    public function __construct($objectname, ficoraEppDomain $addinfo = null, ficoraEppDomain $removeinfo = null, ficoraEppDomain $updateinfo = null, $forcehostattr=false, $namespacesinroot=false)
+    {
+        parent::__construct($objectname, $addinfo, $removeinfo, $updateinfo, $forcehostattr, $namespacesinroot);
+    }
+
+    /**
+     *
+     * @param \domElement $element
+     * @param eppDomain $domain ficoraEppDomain element containing changes
+     */
+    protected function addDomainChanges($element, eppDomain $domain) {
+        // can't change function argument class due to strict standards warning
+        if (!$domain instanceof ficoraEppDomain) {
+            throw new eppException('Domains passed to ficoraEppUpdateDomainRequest must be instances of ficoraEppDomain');
+        }
+
+        if ($domain->getRegistrant()) {
+            $element->appendChild($this->createElement('domain:registrant', $domain->getRegistrant()));
+        }
+        $hosts = $domain->getHosts();
+        if (is_array($hosts) && (count($hosts))) {
+            $nameservers = $this->createElement('domain:ns');
+            foreach ($hosts as $host) {
+                /* @var eppHost $host */
+                if (($this->getForcehostattr()) ||  (is_array($host->getIpAddresses()))) {
+                    $nameservers->appendChild($this->addDomainHostAttr($host));
+                } else {
+                    $nameservers->appendChild($this->addDomainHostObj($host));
+                }
+            }
+            $element->appendChild($nameservers);
+        }
+        $contacts = $domain->getContacts();
+        if (is_array($contacts)) {
+            foreach ($contacts as $contact) {
+                /* @var eppContactHandle $contact */
+                $this->addDomainContact($element, $contact->getContactHandle(), $contact->getContactType());
+            }
+        }
+        $statuses = $domain->getStatuses();
+        if (is_array($statuses)) {
+            foreach ($statuses as $status) {
+                $this->addDomainStatus($element, $status);
+            }
+        }
+
+        // authinfo might contain domain:pw (provider transfer key) and/or domain:pwregistranttransfer (registrant transfer key)
+        // registrant transfer key must be present on registrant change, empty one is valid if registry number doesn't change
+        if (strlen($domain->getAuthorisationCode()) || $domain->getRegistrant() || $domain->getRegistrantTransferCode()) {
+            $authinfo = $this->createElement('domain:authInfo');
+            if (strlen($domain->getAuthorisationCode())) {
+                $pw = $this->createElement('domain:pw');
+                $pw->appendChild($this->createCDATASection($domain->getAuthorisationCode()));
+                $authinfo->appendChild($pw);
+            } else if ($domain->getRegistrant() || $domain->getRegistrantTransferCode()) {
+                $registrantPassword = $this->createElement('domain:pwregistranttransfer', $domain->getRegistrantTransferCode());
+                $authinfo->appendChild($registrantPassword);
+            }
+            $element->appendChild($authinfo);
+        }
+    }
+}

--- a/Protocols/EPP/eppExtensions/ficora/includes.php
+++ b/Protocols/EPP/eppExtensions/ficora/includes.php
@@ -1,8 +1,10 @@
 <?php
 
 include_once(dirname(__FILE__) . '/eppData/ficoraEppContactPostalInfo.php');
+include_once(dirname(__FILE__) . '/eppData/ficoraEppDomain.php');
 include_once(dirname(__FILE__) . '/eppRequests/ficoraEppCreateContactRequest.php');
 include_once(dirname(__FILE__) . '/eppResponses/ficoraEppCheckContactResponse.php');
 include_once(dirname(__FILE__) . '/eppRequests/ficoraEppCheckBalanceRequest.php');
+include_once(dirname(__FILE__) . '/eppRequests/ficoraEppUpdateDomainRequest.php');
 include_once(dirname(__FILE__) . '/eppResponses/ficoraEppCheckBalanceResponse.php');
 include_once(dirname(__FILE__) . '/eppResponses/ficoraEppInfoContactResponse.php');

--- a/Protocols/EPP/eppRequests/eppUpdateDomainRequest.php
+++ b/Protocols/EPP/eppRequests/eppUpdateDomainRequest.php
@@ -66,7 +66,7 @@ class eppUpdateDomainRequest extends eppDomainRequest {
      * @param \domElement $element
      * @param eppDomain $domain
      */
-    private function addDomainChanges($element, eppDomain $domain) {
+    protected function addDomainChanges($element, eppDomain $domain) {
         if ($domain->getRegistrant()) {
             $element->appendChild($this->createElement('domain:registrant', $domain->getRegistrant()));
         }
@@ -111,7 +111,7 @@ class eppUpdateDomainRequest extends eppDomainRequest {
      * @param \domElement $element
      * @param string $status
      */
-    private function addDomainStatus($element, $status) {
+    protected function addDomainStatus($element, $status) {
         $stat = $this->createElement('domain:status');
         $stat->setAttribute('s', $status);
         $element->appendChild($stat);
@@ -124,7 +124,7 @@ class eppUpdateDomainRequest extends eppDomainRequest {
      * @param string $contactid
      * @param string $contacttype
      */
-    private function addDomainContact($domain, $contactid, $contacttype) {
+    protected function addDomainContact($domain, $contactid, $contacttype) {
         $domaincontact = $this->createElement('domain:contact', $contactid);
         $domaincontact->setAttribute('type', $contacttype);
         $domain->appendChild($domaincontact);
@@ -136,7 +136,7 @@ class eppUpdateDomainRequest extends eppDomainRequest {
      * @param eppHost $host
      * @return \domElement
      */
-    private function addDomainHostAttr(eppHost $host) {
+    protected function addDomainHostAttr(eppHost $host) {
 
         $ns = $this->createElement('domain:hostAttr');
         $ns->appendChild($this->createElement('domain:hostName', $host->getHostname()));
@@ -156,7 +156,7 @@ class eppUpdateDomainRequest extends eppDomainRequest {
      * @param eppHost $host
      * @return \domElement
      */
-    private function addDomainHostObj(eppHost $host) {
+    protected function addDomainHostObj(eppHost $host) {
         $ns = $this->createElement('domain:hostObj', $host->getHostname());
         return $ns;
     }

--- a/Registries/ficoraEppConnection/eppConnection.php
+++ b/Registries/ficoraEppConnection/eppConnection.php
@@ -20,7 +20,6 @@ class ficoraEppConnection extends eppConnection {
         // Add the commands and responses specific to this registry
         // Please make sure the corresponding PHP files are present!
         parent::addCommandResponse('Metaregistrar\EPP\ficoraEppCreateContactRequest', 'Metaregistrar\EPP\eppCreateContactResponse');
-        parent::addCommandResponse('Metaregistrar\EPP\eppCheckContactRequest', 'Metaregistrar\EPP\ficoraEppCheckContactResponse');
         parent::addCommandResponse('Metaregistrar\EPP\ficoraEppCheckBalanceRequest', 'Metaregistrar\EPP\ficoraEppCheckBalanceResponse');
         parent::addCommandResponse('Metaregistrar\EPP\ficoraEppUpdateDomainRequest', 'Metaregistrar\EPP\eppUpdateDomainResponse');
         parent::addCommandResponse('Metaregistrar\EPP\eppInfoContactRequest', 'Metaregistrar\EPP\ficoraEppInfoContactResponse');

--- a/Registries/ficoraEppConnection/eppConnection.php
+++ b/Registries/ficoraEppConnection/eppConnection.php
@@ -22,6 +22,7 @@ class ficoraEppConnection extends eppConnection {
         parent::addCommandResponse('Metaregistrar\EPP\ficoraEppCreateContactRequest', 'Metaregistrar\EPP\eppCreateContactResponse');
         parent::addCommandResponse('Metaregistrar\EPP\eppCheckContactRequest', 'Metaregistrar\EPP\ficoraEppCheckContactResponse');
         parent::addCommandResponse('Metaregistrar\EPP\ficoraEppCheckBalanceRequest', 'Metaregistrar\EPP\ficoraEppCheckBalanceResponse');
+        parent::addCommandResponse('Metaregistrar\EPP\ficoraEppUpdateDomainRequest', 'Metaregistrar\EPP\eppUpdateDomainResponse');
         parent::addCommandResponse('Metaregistrar\EPP\eppInfoContactRequest', 'Metaregistrar\EPP\ficoraEppInfoContactResponse');
     }
 


### PR DESCRIPTION
Changes:

- contact check no longer uses custom response class (response element changed)
- domain update request methods changed from private to protected to allow extending
- new *.fi -specific domain update request
- status operations are not allowed in the update request (not supported at registry)
- possible to request and remove registrant transfer key
- possible to change registrant