### PR TITLE
Fix: eppInfoDomainRequest, use null for the eppDomain authorisationCode

### DIFF
--- a/Protocols/EPP/eppData/eppDomain.php
+++ b/Protocols/EPP/eppData/eppDomain.php
@@ -65,7 +65,7 @@ class eppDomain {
      *
      * @var string
      */
-    private $authorisationCode = '';
+    private $authorisationCode = null;
     /**
      *
      * @var integer


### PR DESCRIPTION
This solves #67. Used null instead of an empty string for the eppDomain authorisationCode.