### PR TITLE
Implement Norid domain transfer request

### DIFF
--- a/Protocols/EPP/eppExtensions/norid/eppData/noridEppDomain.php
+++ b/Protocols/EPP/eppExtensions/norid/eppData/noridEppDomain.php
@@ -11,10 +11,8 @@ class noridEppDomain extends eppDomain {
     private $extApplicantDatasetVersionNumber = '2.0';
     private $extApplicantDatasetAcceptName = null;
     private $extApplicantDatasetAcceptDate = null;
-    private $extApplicantDatasetUpdateClientID = null;
-    private $extApplicantDatasetUpdateDate = null;
 
-    public function __construct($domainname, $registrant = null, $contacts = null, $hosts = null, $period = 0, $authorisationCode = null, $extToken = null, $extNotifyMobilePhone = null, $extNotifyEmail = null, $extDeleteFromDNS = null, $extDeleteFromRegistry = null, $extApplicantDatasetVersionNumber = null, $extApplicantDatasetAcceptName = null, $extApplicantDatasetAcceptDate = null, $extApplicantDatasetUpdateClientID = null, $extApplicantDatasetUpdateDate = null) {
+    public function __construct($domainname, $registrant = null, $contacts = null, $hosts = null, $period = 0, $authorisationCode = null, $extToken = null, $extNotifyMobilePhone = null, $extNotifyEmail = null, $extDeleteFromDNS = null, $extDeleteFromRegistry = null, $extApplicantDatasetVersionNumber = null, $extApplicantDatasetAcceptName = null, $extApplicantDatasetAcceptDate = null) {
         parent::__construct($domainname, $registrant, $contacts, $hosts, $period, $authorisationCode);
 
         // Set extension values
@@ -22,7 +20,7 @@ class noridEppDomain extends eppDomain {
         $this->setExtNotify($extNotifyMobilePhone, $extNotifyEmail);
         $this->setExtDeleteFromDNS($extDeleteFromDNS);
         $this->setExtDeleteFromRegistry($extDeleteFromRegistry);
-        $this->setExtApplicantDataset($extApplicantDatasetVersionNumber, $extApplicantDatasetAcceptName, $extApplicantDatasetAcceptDate, $extApplicantDatasetUpdateClientID, $extApplicantDatasetUpdateDate);
+        $this->setExtApplicantDataset($extApplicantDatasetVersionNumber, $extApplicantDatasetAcceptName, $extApplicantDatasetAcceptDate);
     }
 
     public function setExtToken($token) {
@@ -84,7 +82,7 @@ class noridEppDomain extends eppDomain {
         return $this->extDeleteFromRegistry;
     }
 
-    public function setExtApplicantDataset($versionNumber, $acceptName, $acceptDate, $updateClientID, $updateDate) {
+    public function setExtApplicantDataset($versionNumber, $acceptName, $acceptDate) {
         if (!is_null($versionNumber)) {
             $this->extApplicantDatasetVersionNumber = $versionNumber;
         }
@@ -94,21 +92,13 @@ class noridEppDomain extends eppDomain {
         if (!is_null($acceptDate)) {
             $this->extApplicantDatasetAcceptDate = $acceptDate;
         }
-        if (!is_null($updateClientID)) {
-            $this->extApplicantDatasetUpdateClientID = $updateClientID;
-        }
-        if (!is_null($updateDate)) {
-            $this->extApplicantDatasetUpdateDate = $updateDate;
-        }
     }
 
     public function getExtApplicantDataset() {
         return array(
             'versionNumber' => $this->extApplicantDatasetVersionNumber,
             'acceptName' => $this->extApplicantDatasetAcceptName,
-            'acceptDate' => $this->extApplicantDatasetAcceptDate,
-            'updateClientID' => $this->extApplicantDatasetUpdateClientID,
-            'updateDate' => $this->extApplicantDatasetUpdateDate
+            'acceptDate' => $this->extApplicantDatasetAcceptDate
         );
     }
 
@@ -122,14 +112,6 @@ class noridEppDomain extends eppDomain {
 
     public function getExtApplicantDatasetAcceptDate() {
         return $this->extApplicantDatasetAcceptDate;
-    }
-
-    public function getExtApplicantDatasetUpdateClientID() {
-        return $this->extApplicantDatasetUpdateClientID;
-    }
-
-    public function getExtApplicantDatasetUpdateDate() {
-        return $this->extApplicantDatasetUpdateDate;
     }
 
 }

--- a/Protocols/EPP/eppExtensions/norid/eppRequests/noridEppDomainRequestTrait.php
+++ b/Protocols/EPP/eppExtensions/norid/eppRequests/noridEppDomainRequestTrait.php
@@ -5,9 +5,17 @@ trait noridEppDomainRequestTrait {
 
     /**
      * Norid domain extension object to add namespaces to
-     * @var \DomElement
+     * @var \DomElement $domainextension
      */
     protected $domainextension = null;
+
+    /**
+     * Extension for Norid-specific command types
+     * @var \DomElement $extcommand
+     * @var \DomElement $extcommandextension
+     * @var \DomElement $extcommanddomainextension
+     */
+    protected $extcommand = null, $extcommandextension = null, $extcommanddomainextension = null;
 
     protected function getDomainExtension($type) {
         if (is_null($this->domainextension)) {
@@ -15,12 +23,42 @@ trait noridEppDomainRequestTrait {
             if (!$this->rootNamespaces()) {
                 $this->domainextension->setAttribute('xmlns:no-ext-domain', 'http://www.norid.no/xsd/no-ext-domain-1.1');
             }
-            $ext = $this->getExtension();
-            /* @var \DOMElement $ext */
-            $ext->appendChild($this->domainextension);
+            $this->getExtension()->appendChild($this->domainextension);
         }
         
         return $this->domainextension;
+    }
+
+    protected function getExtCommand() {
+        if (is_null($this->extcommand)) {
+            $this->extcommand = $this->createElement('command');
+            if (!$this->rootNamespaces()) {
+                $this->extcommand->setAttribute('xmlns', 'http://www.norid.no/xsd/no-ext-epp-1.0');
+            }
+            $this->getEpp()->appendChild($this->createElement('extension')->appendChild($this->extcommand));
+        }
+        return $this->extcommand;
+    }
+
+    protected function getExtCommandExtension() {
+        if (is_null($this->extcommandextension)) {
+            $this->extcommandextension = $this->createElement('extension');
+            $this->getExtCommand()->appendChild($this->extcommandextension);
+        }
+        
+        return $this->extcommandextension;
+    }
+
+    protected function getExtCommandDomainExtension($type) {
+        if (is_null($this->extcommanddomainextension)) {
+            $this->extcommanddomainextension = $this->createElement('no-ext-domain:'.$type);
+            if (!$this->rootNamespaces()) {
+                $this->extcommanddomainextension->setAttribute('xmlns:no-ext-domain', 'http://www.norid.no/xsd/no-ext-domain-1.1');
+            }
+            $this->getExtCommandExtension()->appendChild($this->extcommanddomainextension);
+        }
+        
+        return $this->extcommanddomainextension;
     }
 
 }

--- a/Protocols/EPP/eppExtensions/norid/eppRequests/noridEppTransferRequest.php
+++ b/Protocols/EPP/eppExtensions/norid/eppRequests/noridEppTransferRequest.php
@@ -1,0 +1,56 @@
+<?php
+namespace Metaregistrar\EPP;
+
+// See https://www.norid.no/no/registrar/system/dokumentasjon/eksempler/?op=dtra for example request/response
+
+class noridEppTransferRequest extends eppTransferRequest {
+
+    const OPERATION_EXECUTE = 'execute';
+
+    use noridEppDomainRequestTrait;
+    
+    protected $domainobject = null;
+
+    function __construct(noridEppDomain $domain, $namespacesinroot = true) {
+        $this->setNamespacesinroot($namespacesinroot);
+        parent::__construct();
+        $this->setDomainExecute($domain);
+        $this->addSessionId();
+    }
+
+    public function setExtDomainExecute(noridEppDomain $domain) {
+        $transfer = $this->createElement('transfer');
+        $transfer->setAttribute('op', self::OPERATION_EXECUTE);
+        $this->domainobject = $this->createElement('domain:transfer');
+        if (!$this->rootNamespaces()) {
+            $this->domainobject->setAttribute('xmlns:domain', 'urn:ietf:params:xml:ns:domain-1.0');
+        }
+        $this->domainobject->appendChild($this->createElement('domain:name', $domain->getDomainname()));
+        if (strlen($domain->getAuthorisationCode())) {
+            $authinfo = $this->createElement('domain:authInfo');
+            $authinfo->appendChild($this->createElement('domain:pw', $domain->getAuthorisationCode()));
+            $this->domainobject->appendChild($authinfo);
+        }
+        if ($domain->getPeriod()) {
+            $domainperiod = $this->createElement('domain:period', $domain->getPeriod());
+            $domainperiod->setAttribute('unit', eppDomain::DOMAIN_PERIOD_UNIT_Y);
+            $this->domainobject->appendChild($domainperiod);
+        }
+        if (strlen($domain->getExtToken())) {
+            $this->getExtCommandDomainExtension('transfer')->appendChild($this->createElement('no-ext-domain:token', $domain->getExtToken()));
+        }
+        if (strlen($domain->getExtNotifyMobilePhone()) || strlen($domain->getExtNotifyEmail())) {
+            $notify = $this->createElement('no-ext-domain:notify');
+            if (strlen($domain->getExtNotifyMobilePhone())) {
+                $notify->appendChild($this->createElement('no-ext-domain:mobilePhone', $domain->getExtNotifyMobilePhone()));
+            }
+            if (strlen($domain->getExtNotifyEmail())) {
+                $notify->appendChild($this->createElement('no-ext-domain:email', $domain->getExtNotifyEmail()));
+            }
+            $this->getExtCommandDomainExtension('transfer')->appendChild($notify);
+        }
+        $transfer->appendChild($this->domainobject);
+        $this->getExtCommand()->appendChild($transfer);
+    }
+
+}

--- a/Protocols/EPP/eppExtensions/norid/eppRequests/noridEppWithdrawDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/norid/eppRequests/noridEppWithdrawDomainRequest.php
@@ -12,23 +12,19 @@ class noridEppWithdrawContactRequest extends eppRequest {
     function __construct(noridEppDomain $domain, $namespacesinroot = true) {
         $this->setNamespacesinroot($namespacesinroot);
         parent::__construct();
-        $this->domainobject = $this->createElement('domain:withdraw');
-        if (!$this->rootNamespaces()) {
-            $this->domainobject->setAttribute('xmlns:no-ext-domain', 'http://www.norid.no/xsd/no-ext-domain-1.1');
-        }
-        $commandobject = $this->createElement('command');
-        if (!$this->rootNamespaces()) {
-            $commandobject->setAttribute('xmlns', 'http://www.norid.no/xsd/no-ext-epp-1.0');
-        }
-        $this->getEpp()->appendChild($this->createElement('extension')->appendChild($commandobject->appendChild($this->createElement('withdraw')->appendChild($this->domainobject))));
         $this->setDomain($domain);
         $this->addSessionId();
     }
 
     public function setDomain(noridEppDomain $domain) {
-        if (!is_null($domain)) {
-            $this->domainobject->appendChild($this->createElement('domain:name', $domain->getDomainname()));
+        $withdraw = $this->createElement('withdraw');
+        $this->domainobject = $this->createElement('domain:withdraw');
+        if (!$this->rootNamespaces()) {
+            $this->domainobject->setAttribute('xmlns:no-ext-domain', 'http://www.norid.no/xsd/no-ext-domain-1.1');
         }
+        $this->domainobject->appendChild($this->createElement('domain:name', $domain->getDomainname()));
+        $withdraw->appendChild($this->domainobject);
+        $this->getExtCommand()->appendChild($withdraw);
     }
 
 }


### PR DESCRIPTION
This pull request will implement Norid's transfer request op="execute" extension. You can find documentation on that extension in section 5.1.5 (page 27) of the following document: https://www.norid.no/registrar/system/dokumentasjon/EPP_Interface_Specification.5p3.pdf

It will also remove read-only application dataset fields from noridEppDomain. Adding them in the first place was a mistake on my behalf.