### PR TITLE
Updates to Norid EPP extension and fixes to some EPP requests

### DIFF
--- a/Protocols/EPP/eppExtensions/norid/eppData/noridEppContact.php
+++ b/Protocols/EPP/eppExtensions/norid/eppData/noridEppContact.php
@@ -22,7 +22,7 @@ class noridEppContact extends eppContact {
     private $extOrganizations = null;
     private $extRoleContacts = null;
 
-    function __construct($postalInfo, $email, $voice, $fax, $password, $status, $extType = null, $extIdentityType = null, $extIdentity = null, $extMobilePhone = null, $extEmails = null, $extOrganizations = null, $extRoleContacts = null) {
+    function __construct($postalInfo = null, $email = null, $voice = null, $fax = null, $password = null, $status = null, $extType = null, $extIdentityType = null, $extIdentity = null, $extMobilePhone = null, $extEmails = null, $extOrganizations = null, $extRoleContacts = null) {
         parent::__construct($postalInfo, $email, $voice, $fax, $password, $status);
         $this->setExtType($extType);
         $this->setExtIdentity($extIdentityType, $extIdentity);

--- a/Protocols/EPP/eppExtensions/norid/eppRequests/noridEppCreateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/norid/eppRequests/noridEppCreateDomainRequest.php
@@ -15,10 +15,10 @@ class noridEppCreateDomainRequest extends eppCreateDomainRequest {
 
     public function setExtDomain(noridEppDomain $domain) {
         // Add Norid applicant dataset
-        $this->addDomainExtApplicantDataset($this->getDomainExtension('create'), $domain);
+        $this->addDomainExtApplicantDataset($domain);
     }
 
-    private function addDomainExtApplicantDataset(\DOMElement $element, noridEppDomain $domain) {
+    private function addDomainExtApplicantDataset(noridEppDomain $domain) {
         $dataset = $domain->getExtApplicantDataset();
         if (is_null($dataset['versionNumber']) || is_null($dataset['acceptName']) || is_null($dataset['acceptDate'])) {
             throw new eppException('A valid applicant dataset is required to create a domain in the Norid registry');
@@ -27,7 +27,7 @@ class noridEppCreateDomainRequest extends eppCreateDomainRequest {
         $datasetElement->appendChild($this->createElement('no-ext-domain:versionNumber', $dataset['versionNumber']));
         $datasetElement->appendChild($this->createElement('no-ext-domain:acceptName', $dataset['acceptName']));
         $datasetElement->appendChild($this->createElement('no-ext-domain:acceptDate', $dataset['acceptDate']));
-        $element->appendChild($datasetElement);
+        $this->getDomainExtension('create')->appendChild($datasetElement);
     }
 
 }

--- a/Protocols/EPP/eppExtensions/norid/eppRequests/noridEppTransferRequest.php
+++ b/Protocols/EPP/eppExtensions/norid/eppRequests/noridEppTransferRequest.php
@@ -11,10 +11,15 @@ class noridEppTransferRequest extends eppTransferRequest {
     
     protected $domainobject = null;
 
-    function __construct(noridEppDomain $domain, $namespacesinroot = true) {
-        $this->setNamespacesinroot($namespacesinroot);
-        parent::__construct();
-        $this->setDomainExecute($domain);
+    function __construct($operation, $object) {
+        parent::__construct($operation, $object);
+        if ($operation == self::OPERATION_EXECUTE) {
+            if ($object instanceof noridEppDomain) {
+                $this->setDomainExecute($object);
+            } else {
+                throw new eppException('Object parameter should be an instance of noridEppDomain when operation is EXECUTE');
+            }
+        }
         $this->addSessionId();
     }
 

--- a/Protocols/EPP/eppExtensions/secDNS-1.1/eppRequests/eppDnssecUpdateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/secDNS-1.1/eppRequests/eppDnssecUpdateDomainRequest.php
@@ -41,9 +41,9 @@ class eppDnssecUpdateDomainRequest extends eppUpdateDomainRequest {
         $secdns->setAttribute('xmlns:secDNS', 'urn:ietf:params:xml:ns:secDNS-1.1');
         if ($removeinfo instanceof eppDomain) {
             $dnssecs = $removeinfo->getSecdns();
+            $rem = $this->createElement('secDNS:rem');
             foreach ($dnssecs as $dnssec) {
                 /* @var $dnssec eppSecdns */
-                $rem = $this->createElement('secDNS:rem');
                 if (strlen($dnssec->getPubkey()) > 0) {
                     $keydata = $this->createElement('secDNS:keyData');
                     $keydata->appendChild($this->createElement('secDNS:flags', $dnssec->getFlags()));
@@ -63,14 +63,14 @@ class eppDnssecUpdateDomainRequest extends eppUpdateDomainRequest {
                     $dsdata->appendChild($this->createElement('secDNS:digest', $dnssec->getDigest()));
                     $rem->appendChild($dsdata);
                 }
-                $secdns->appendChild($rem);
             }
+            $secdns->appendChild($rem);
         }
         if ($addinfo instanceof eppDomain) {
             $dnssecs = $addinfo->getSecdns();
+            $add = $this->createElement('secDNS:add');
             foreach ($dnssecs as $dnssec) {
                 /* @var $dnssec eppSecdns */
-                $add = $this->createElement('secDNS:add');
                 if (strlen($dnssec->getPubkey()) > 0) {
                     $keydata = $this->createElement('secDNS:keyData');
                     $keydata->appendChild($this->createElement('secDNS:flags', $dnssec->getFlags()));
@@ -90,8 +90,8 @@ class eppDnssecUpdateDomainRequest extends eppUpdateDomainRequest {
                     $dsdata->appendChild($this->createElement('secDNS:digest', $dnssec->getDigest()));
                     $add->appendChild($dsdata);
                 }
-                $secdns->appendChild($add);
             }
+            $secdns->appendChild($add);
         }
         $this->getExtension()->appendchild($secdns);
         $this->addSessionId();

--- a/Protocols/EPP/eppRequests/eppTransferRequest.php
+++ b/Protocols/EPP/eppRequests/eppTransferRequest.php
@@ -66,9 +66,8 @@ class eppTransferRequest extends eppRequest {
                 }
                 break;
             default:
-                throw new eppException('Operation parameter needs to be QUERY, REQUEST, CANCEL, APPROVE or REJECT on eppTransferRequest');
+                trigger_error('Operation parameter should be QUERY, REQUEST, CANCEL, APPROVE or REJECT on eppTransferRequest, ignore this if you are using a custom transfer operation', E_USER_NOTICE);
                 break;
-
         }
         $this->addSessionId();
     }


### PR DESCRIPTION
Updated eppDnssecUpdateDomainRequest to be compliant with section [5.2.5](https://tools.ietf.org/html/rfc5910#section-5.2.5) of [RFC 5910](https://tools.ietf.org/html/rfc5910)

Changed eppTransferRequest to not throw upon an unknown operation, but rather create a notice. This allows extensions upon eppTransferRequest that create a new transfer operation.

The rest of the changes apply to the Norid extension, and are briefly explained in the commit messages.