### PR TITLE
Added EURID contact-ext-1.1 extension.

### DIFF
--- a/Protocols/EPP/eppExtensions/contact-ext-1.1/eppData/euridEppContact.php
+++ b/Protocols/EPP/eppExtensions/contact-ext-1.1/eppData/euridEppContact.php
@@ -1,0 +1,64 @@
+<?php
+namespace Metaregistrar\EPP;
+/**
+ * The Contact Info Object
+ *
+ * This will hold the complete contact info a registry can receive and give you
+ *
+ */
+
+class euridEppContact extends eppContact {
+
+
+    #
+    # These values can be set into the contactExtType field
+    # The type of contact to create. Can be one of: “registrant”, “onsite”, "reseller", “tech”.
+    #
+
+    const CONTACT_EXT_TYPES = ['registrant', 'tech', 'onsite', 'reseller'];
+
+
+    private $contactExtType;
+    private $contactExtLang = 'en';
+    private $contactExtVat  = null;
+
+
+    public function __construct($postalInfo = null, $email = null, $voice = null, $fax = null, $password = null, $status = null) {
+       parent::__construct($postalInfo , $email , $voice , $fax , $password , $status );
+    }
+
+
+    public function setContactExtType($type)
+    {
+
+        if(in_array($type, self::CONTACT_EXT_TYPES)) {
+            $this->contactExtType =  $type;
+        }
+    }
+
+    public function setContactExtLang($lang)
+    {
+        $this->contactExtLang =  $lang;
+    }
+
+    public function setContactExtVat($vat)
+    {
+        $this->contactExtVat =  $vat;
+    }
+
+    public function getContactExtType()
+    {
+        return $this->contactExtType;
+    }
+
+    public function getContactExtLang()
+    {
+        return $this->contactExtLang;
+    }
+
+    public function getContactExtVat()
+    {
+        return $this->contactExtVat;
+    }
+
+}

--- a/Protocols/EPP/eppExtensions/contact-ext-1.1/eppRequests/euridEppCreateContactRequest.php
+++ b/Protocols/EPP/eppExtensions/contact-ext-1.1/eppRequests/euridEppCreateContactRequest.php
@@ -1,0 +1,45 @@
+<?php
+namespace Metaregistrar\EPP;
+/*
+<extension>
+    <contact-ext:create>
+        <contact-ext:type>registrant</contact-ext:type>
+        <contact-ext:lang>en</contact-ext:lang>
+    </contact-ext:create>
+</extension>
+
+*/
+
+class euridEppCreateContactRequest extends eppCreateContactRequest {
+
+    /**
+     * euridEppCreateContactRequest constructor.
+     * @param eppContact|null $createinfo
+     * @param string $contacttype
+     * @param string $language
+     * @throws eppException
+     */
+    function __construct($createinfo) {
+        parent::__construct($createinfo);
+        $this->addContactExtension($createinfo);
+        $this->addSessionId();
+    }
+
+    /**
+     * @param object eppContact
+     */
+    public function addContactExtension(eppContact $createinfo) {
+        $this->addExtension('xmlns:contact-ext', 'http://www.eurid.eu/xml/epp/contact-ext-1.1');
+        $create = $this->createElement('contact-ext:create');
+        if(!empty($createinfo->getContactExtType())) {
+            $create->appendChild($this->createElement('contact-ext:type', $createinfo->getContactExtType()));
+        }
+        if(!empty($createinfo->getContactExtVat())) {
+            $create->appendChild($this->createElement('contact-ext:vat', $createinfo->getContactExtVat()));
+        }
+        $create->appendChild($this->createElement('contact-ext:lang', $createinfo->getContactExtLang()));
+
+        $this->getExtension()->appendChild($create);
+    }
+
+}

--- a/Protocols/EPP/eppExtensions/contact-ext-1.1/includes.php
+++ b/Protocols/EPP/eppExtensions/contact-ext-1.1/includes.php
@@ -1,0 +1,10 @@
+<?php
+$this->addExtension('contact-ext', 'http://www.eurid.eu/xml/epp/contact-ext-1.1');
+
+include_once(dirname(__FILE__) . '/eppData/euridEppContact.php');
+include_once(dirname(__FILE__) . '/eppRequests/euridEppCreateContactRequest.php');
+//include_once(dirname(__FILE__) . '/eppResponses/euridEppCreateContactResponse.php');
+
+$this->addCommandResponse('Metaregistrar\EPP\euridEppCreateContactRequest', 'Metaregistrar\EPP\eppCreateContactResponse');
+
+

--- a/Registries/euridEppConnection/eppConnection.php
+++ b/Registries/euridEppConnection/eppConnection.php
@@ -10,6 +10,7 @@ class euridEppConnection extends eppConnection {
         parent::setServices(array('urn:ietf:params:xml:ns:domain-1.0' => 'domain', 'urn:ietf:params:xml:ns:contact-1.0' => 'contact'));
         parent::useExtension('authInfo-1.1');
         parent::useExtension('domain-ext-2.1');
+        parent::useExtension('contact-ext-1.1');
 
     }
 


### PR DESCRIPTION
EURID contact-ext-1.1 extension for contacts.

How to use it:

```
$contact = new euridEppContact ($postalInfo, $email, $voice);
$contact->setContactExtType('tech');
$contact->setContactExtVat('XXXXX');
$contact->setContactExtLang('en');
```

Output:

```
<extension>
<contact-ext:create>
<contact-ext:type>tech</contact-ext:type>
<contact-ext:vat>XXXXX</contact-ext:vat>
<contact-ext:lang>en</contact-ext:lang>
</contact-ext:create>
</extension>
```

