### PR TITLE
override id and password for parent in noridEppContact.php

### DIFF
--- a/Protocols/EPP/eppExtensions/no-ext-contact-1.0/eppData/noridEppContact.php
+++ b/Protocols/EPP/eppExtensions/no-ext-contact-1.0/eppData/noridEppContact.php
@@ -24,6 +24,14 @@ class noridEppContact extends eppContact {
 
     function __construct($postalInfo = null, $email = null, $voice = null, $fax = null, $password = null, $status = null, $extType = null, $extIdentityType = null, $extIdentity = null, $extMobilePhone = null, $extEmails = null, $extOrganizations = null, $extRoleContacts = null) {
         parent::__construct($postalInfo, $email, $voice, $fax, $password, $status);
+
+        // Norid requires id to be auto
+        $this->setId('auto');
+
+        // Norid requires empty [authInfo/pw] set, but does not support values yet. Pass value ' ' to this class
+        // override eppContact constructor
+        $this->setPassword($password);
+
         $this->setExtType($extType);
         $this->setExtIdentity($extIdentityType, $extIdentity);
         $this->setExtMobilePhone($extMobilePhone);

--- a/Protocols/EPP/eppExtensions/no-ext-domain-1.1/eppRequests/noridEppCreateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/no-ext-domain-1.1/eppRequests/noridEppCreateDomainRequest.php
@@ -27,7 +27,7 @@ class noridEppCreateDomainRequest extends eppCreateDomainRequest {
         $datasetElement->appendChild($this->createElement('no-ext-domain:versionNumber', $dataset['versionNumber']));
         $datasetElement->appendChild($this->createElement('no-ext-domain:acceptName', $dataset['acceptName']));
         $datasetElement->appendChild($this->createElement('no-ext-domain:acceptDate', $dataset['acceptDate']));
-        $this->getDomainExtension('create')->appendChild($datasetElement);
+        $this->getExtDomainExtension('create')->appendChild($datasetElement);
     }
 
 }

--- a/Protocols/EPP/eppExtensions/no-ext-domain-1.1/includes.php
+++ b/Protocols/EPP/eppExtensions/no-ext-domain-1.1/includes.php
@@ -8,7 +8,7 @@ include_once(dirname(__FILE__) . '/eppResponses/noridEppResponseTrait.php');
 
 // Domain Create/Withdraw
 include_once(dirname(__FILE__) . '/eppRequests/noridEppCreateDomainRequest.php');
-include_once(dirname(__FILE__) . '/eppRequests/noridEppCreateDomainResponse.php');
+include_once(dirname(__FILE__) . '/eppResponses/noridEppCreateDomainResponse.php');
 $this->addCommandResponse('Metaregistrar\\EPP\\noridEppCreateDomainRequest', 'Metaregistrar\\EPP\\noridEppCreateDomainResponse');
 
 include_once(dirname(__FILE__) . '/eppRequests/noridEppWithdrawDomainRequest.php');


### PR DESCRIPTION
The parent constructor sets incompatible data for NORID, so we have to override them.