### PR TITLE
Norid: Fix domain update request structure

### DIFF
--- a/Protocols/EPP/eppExtensions/no-ext-domain-1.1/eppRequests/noridEppUpdateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/no-ext-domain-1.1/eppRequests/noridEppUpdateDomainRequest.php
@@ -27,7 +27,9 @@ class noridEppUpdateDomainRequest extends eppDnssecUpdateDomainRequest {
         $datasetElement->appendChild($this->createElement('no-ext-domain:versionNumber', $dataset['versionNumber']));
         $datasetElement->appendChild($this->createElement('no-ext-domain:acceptName', $dataset['acceptName']));
         $datasetElement->appendChild($this->createElement('no-ext-domain:acceptDate', $dataset['acceptDate']));
-        $this->getExtDomainExtension('update')->appendChild($datasetElement);
+        $changeElement = $this->createElement('no-ext-domain:chg');
+        $changeElement->appendChild($datasetElement);
+        $this->getExtDomainExtension('update')->appendChild($changeElement);
     }
 
 }


### PR DESCRIPTION
The `no-ext-domain:applicantDataset` was placed straight into a `no-ext-domain:update` element. It should have been wrapped in an `no-ext-domain:chg` element inside `no-ext-domain:update`.

See #186.