### PR TITLE
Norid: Make update domain request consistent

### DIFF
--- a/Protocols/EPP/eppExtensions/no-ext-domain-1.1/eppData/noridEppDomain.php
+++ b/Protocols/EPP/eppExtensions/no-ext-domain-1.1/eppData/noridEppDomain.php
@@ -8,7 +8,7 @@ class noridEppDomain extends eppDomain {
     private $extNotifyEmail = null;
     private $extDeleteFromDNS = null;
     private $extDeleteFromRegistry = null;
-    private $extApplicantDatasetVersionNumber = '2.0';
+    private $extApplicantDatasetVersionNumber = '3.0';
     private $extApplicantDatasetAcceptName = null;
     private $extApplicantDatasetAcceptDate = null;
 


### PR DESCRIPTION
I noticed that the `noridEppUpdateDomainRequest` constructor was inconsistent with other update domain requests, such as `eppDnssecUpdateDomainRequest`. This change fixes that, making it a bit less confusing.

It is also backwards compatible with the old constructor by setting applicant dataset on `$updateinfo` if it was set on `$domain`/`$objectname`, so it should not break any current implementations.

The applicant dataset default version number has also been bumped to `3.0`, as per https://www.norid.no/en/registrar/soknad/veiledning/egenerklaring-veiledning/.