### PR TITLE
Invalid foreach loop in getNsgroupHosts

### DIFF
--- a/Protocols/EPP/eppExtensions/nsgroup-1.0/eppResponses/dnsbeEppInfoNsgroupResponse.php
+++ b/Protocols/EPP/eppExtensions/nsgroup-1.0/eppResponses/dnsbeEppInfoNsgroupResponse.php
@@ -48,7 +48,7 @@ class dnsbeEppInfoNsgroupResponse extends eppResponse {
         $xpath = $this->xPath();
         $result = $xpath->query('/epp:epp/epp:response/epp:resData/nsgroup:infData/nsgroup:ns');
         if ($result->length > 0) {
-            foreach ($result->item as $item) {
+            foreach ($result as $item) {
                 $return[] = $item->nodeValue;
             }
         }


### PR DESCRIPTION
This PR fixes an issue in the getNsgroupHosts where there was an invalid foreach loop resulting in an error.