### PR TITLE
get original response in exception

### DIFF
--- a/Protocols/EPP/eppException.php
+++ b/Protocols/EPP/eppException.php
@@ -14,6 +14,10 @@ class eppException extends \Exception {
      * @var string
      */
     private $lastcommand = null;
+    /**
+     * @var $response
+     */
+    private $response = null;
 
     /**
      * eppException constructor.
@@ -23,8 +27,9 @@ class eppException extends \Exception {
      * @param string $reason
      * @param int $id
      * @param string $command
+     * @param \Metaregistrar\EPP\eppResponse|null $response
      */
-    public function __construct($message = "", $code = 0, \Exception $previous = null, $reason = null, $command = null) {
+    public function __construct($message = "", $code = 0, \Exception $previous = null, $reason = null, $command = null, $response = null) {
         $this->reason = $reason;
         $trace = $this->getTrace();
         $this->class = null;
@@ -35,6 +40,7 @@ class eppException extends \Exception {
             /* @var $class \Metaregistrar\EPP\eppRequest */
             $this->lastcommand = $command;
         }
+        $this->response = $response;
         parent::__construct($message, $code, $previous);
     }
 
@@ -57,6 +63,13 @@ class eppException extends \Exception {
      */
     public function getReason() {
         return $this->reason;
+    }
+
+    /**
+     * @return \Metaregistrar\EPP\eppResponse|null
+     */
+    public function getResponse() {
+        return $this->response;
     }
 }
 

--- a/Protocols/EPP/eppResponses/eppResponse.php
+++ b/Protocols/EPP/eppResponses/eppResponse.php
@@ -182,10 +182,10 @@ class eppResponse extends \DOMDocument {
             }
             if ((is_array($this->exceptions)) && (count($this->exceptions)>0)) {
                 foreach ($this->exceptions as $exceptionhandler) {
-                    throw new $exceptionhandler($errorstring, $resultcode, null, $resultreason, $this->saveXML());
+                    throw new $exceptionhandler($errorstring, $resultcode, null, $resultreason, $this->saveXML(), $this);
                 }
             } else {
-                throw new eppException($errorstring, $resultcode, null, $resultreason, $this->saveXML());
+                throw new eppException($errorstring, $resultcode, null, $resultreason, $this->saveXML(), $this);
             }
 
         } else {


### PR DESCRIPTION
Includes the original response in the exceptions.
Please look over it, I'm not really used to standards, but this works out great while I tested it.

closes #194 