### PR TITLE
Norid: Fix domain transfer op=request

### DIFF
--- a/Protocols/EPP/eppExtensions/no-ext-domain-1.1/eppRequests/noridEppTransferRequest.php
+++ b/Protocols/EPP/eppExtensions/no-ext-domain-1.1/eppRequests/noridEppTransferRequest.php
@@ -13,11 +13,11 @@ class noridEppTransferRequest extends eppTransferRequest {
 
     function __construct($operation, $object) {
         parent::__construct($operation, $object);
-        $remove = $this->getElementsByTagName('command');
-        foreach ($remove as $node) {
-            $node->parentNode->removeChild($node);
-        }
         if ($operation == self::OPERATION_EXECUTE) {
+            $remove = $this->getElementsByTagName('command');
+            foreach ($remove as $node) {
+                $node->parentNode->removeChild($node);
+            }
             if ($object instanceof noridEppDomain) {
                 $this->setExtDomainExecute($object);
             } else {


### PR DESCRIPTION
Ref. #202 Norid domain transfer `op="request"` is broken as command element is removed for `op="execute"`.

Changed to only remove command element if operation is actually execute.