### PR TITLE
Various Norid fixes and a Metaregistrar addition

### DIFF
--- a/Protocols/EPP/eppExtensions/command-ext-1.0/eppResponses/metaregInfoDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/command-ext-1.0/eppResponses/metaregInfoDomainResponse.php
@@ -1,0 +1,48 @@
+<?php
+namespace Metaregistrar\EPP;
+
+class metaregInfoDomainResponse extends eppInfoDomainResponse {
+
+    /**
+     * Gets the domain command-ext-domain:autoRenew field as a boolean
+     * as per Metaregistrar command-ext-domain-1.0.xsd
+     *
+     * @return bool autoRenew
+     */
+    public function getAutoRenew() {
+        $val = $this->queryPath('/epp:epp/epp:response/epp:extension/command-ext-domain:extInfData/autoRenew');
+        if (!$val) {
+            return false;
+        }
+        return strtolower($val) === 'true';
+    }
+
+    /**
+     * Gets the domain command-ext-domain:autoRenewPeriod field as an integer
+     * as per Metaregistrar command-ext-domain-1.0.xsd
+     *
+     * @return int autoRenewPeriod
+     */
+    public function getAutoRenewPeriod() {
+        $val = $this->queryPath('/epp:epp/epp:response/epp:extension/command-ext-domain:extInfData/autoRenewPeriod');
+        if (!$val) {
+            return false;
+        }
+        return intval($val);
+    }
+
+    /**
+     * Gets the domain command-ext-domain:privacyOptions field as a boolean
+     * as per Metaregistrar command-ext-domain-1.0.xsd
+     *
+     * @return bool privacyOptions
+     */
+    public function getPrivacy() {
+        $val = $this->queryPath('/epp:epp/epp:response/epp:extension/command-ext-domain:extInfData/autoRenew');
+        if (!$val) {
+            return false;
+        }
+        return strtolower($val) === 'true';
+    }
+
+}

--- a/Protocols/EPP/eppExtensions/command-ext-1.0/includes.php
+++ b/Protocols/EPP/eppExtensions/command-ext-1.0/includes.php
@@ -12,7 +12,8 @@ $this->addCommandResponse('Metaregistrar\EPP\metaregEppAutorenewRequest', 'Metar
 
 include_once(dirname(__FILE__) . '/eppData/metaregInfoDomainOptions.php');
 include_once(dirname(__FILE__) . '/eppRequests/metaregInfoDomainRequest.php');
-$this->addCommandResponse('Metaregistrar\EPP\metaregInfoDomainRequest', 'Metaregistrar\EPP\eppInfoDomainResponse');
+include_once(dirname(__FILE__) . '/eppResponses/metaregInfoDomainResponse.php');
+$this->addCommandResponse('Metaregistrar\EPP\metaregInfoDomainRequest', 'Metaregistrar\EPP\metaregInfoDomainResponse');
 
 include_once(dirname(__FILE__) . '/eppRequests/metaregEppAuthcodeRequest.php');
 $this->addCommandResponse('Metaregistrar\EPP\metaregEppAuthcodeRequest', 'Metaregistrar\EPP\eppInfoDomainResponse');

--- a/Protocols/EPP/eppExtensions/no-ext-contact-1.0/eppRequests/noridEppUpdateContactRequest.php
+++ b/Protocols/EPP/eppExtensions/no-ext-contact-1.0/eppRequests/noridEppUpdateContactRequest.php
@@ -11,14 +11,15 @@ class noridEppUpdateContactRequest extends eppUpdateContactRequest {
         parent::__construct($objectname, $addInfo, $removeInfo, $updateInfo, $namespacesinroot);
 
         if (($addInfo instanceof noridEppContact) || ($removeInfo instanceof noridEppContact) || ($updateInfo instanceof noridEppContact)) {
-            $this->updateExtContact($addInfo, $removeInfo, null);
+            $this->updateExtContact($addInfo, $removeInfo, $updateInfo);
         }
 
         $this->addSessionId();
     }
 
     public function updateExtContact($addInfo, $removeInfo, $updateInfo) {
-        if ($updateInfo instanceof noridEppContact) {            // Add Norid EPP extensions
+        // Add Norid EPP extensions
+        if ($updateInfo instanceof noridEppContact) {
             if (!is_null($updateInfo->getExtOrganizations()) || (!is_null($updateInfo->getExtIdentityType()) && !is_null($updateInfo->getExtIdentity())) || !is_null($updateInfo->getExtMobilePhone()) || !is_null($updateInfo->getExtEmails()) || !is_null($updateInfo->getExtRoleContacts())) {
                 $extchgcmd = $this->createElement('no-ext-contact:chg');
                 $this->addContactExtChanges($extchgcmd, $updateInfo);

--- a/Protocols/EPP/eppExtensions/no-ext-domain-1.1/eppRequests/noridEppWithdrawDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/no-ext-domain-1.1/eppRequests/noridEppWithdrawDomainRequest.php
@@ -3,7 +3,7 @@ namespace Metaregistrar\EPP;
 
 // See https://www.norid.no/no/registrar/system/dokumentasjon/eksempler/?op=dwit for example request/response
 
-class noridEppWithdrawContactRequest extends eppRequest {
+class noridEppWithdrawDomainRequest extends eppRequest {
 
     use noridEppDomainRequestTrait;
     

--- a/Protocols/EPP/eppExtensions/no-ext-domain-1.1/eppRequests/noridEppWithdrawDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/no-ext-domain-1.1/eppRequests/noridEppWithdrawDomainRequest.php
@@ -22,11 +22,11 @@ class noridEppWithdrawDomainRequest extends eppRequest {
 
     public function setDomain(noridEppDomain $domain) {
         $withdraw = $this->createElement('withdraw');
-        $this->domainobject = $this->createElement('domain:withdraw');
+        $this->domainobject = $this->createElement('no-ext-domain:withdraw');
         if (!$this->rootNamespaces()) {
             $this->domainobject->setAttribute('xmlns:no-ext-domain', 'http://www.norid.no/xsd/no-ext-domain-1.1');
         }
-        $this->domainobject->appendChild($this->createElement('domain:name', $domain->getDomainname()));
+        $this->domainobject->appendChild($this->createElement('no-ext-domain:name', $domain->getDomainname()));
         $withdraw->appendChild($this->domainobject);
         $this->getExtCommand()->appendChild($withdraw);
     }

--- a/Protocols/EPP/eppExtensions/no-ext-domain-1.1/eppResponses/noridEppWithdrawDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/no-ext-domain-1.1/eppResponses/noridEppWithdrawDomainResponse.php
@@ -3,7 +3,7 @@ namespace Metaregistrar\EPP;
 
 // See https://www.norid.no/no/registrar/system/dokumentasjon/eksempler/?op=dwit for example request/response
 
-class noridEppWithdrawContactResponse extends eppResponse {
+class noridEppWithdrawDomainResponse extends eppResponse {
     
     use noridEppResponseTrait;
 


### PR DESCRIPTION
- Norid: Fixes class name conflict between `noridEppWithdrawDomainRequest` and `noridEppWithdrawContactRequest`
- Norid: Fixes class name conflict between `noridEppWithdrawDomainResponse` and `noridEppWithdrawContactResponse`
- Norid: Fixes XML namespace being wrong in `noridEppWithdrawDomainRequest`
- Norid: Fixes `$updateInfo` not being passed to `updateExtContact` in `noridEppUpdateContactRequest` constructor
- Metaregistrar: Adds `metaregInfoDomainResponse` with methods to read values from the `command-ext-domain-1.0` extension