### PR TITLE
Added Registrar:info for DNSbe

### DIFF
--- a/Protocols/EPP/eppExtensions/registrar-1.0/eppRequests/dnsbeEppRegistrarInfoRequest.php
+++ b/Protocols/EPP/eppExtensions/registrar-1.0/eppRequests/dnsbeEppRegistrarInfoRequest.php
@@ -1,0 +1,25 @@
+<?php
+namespace Metaregistrar\EPP;
+/*
+
+<info>
+    <registrar:info/>
+</info>
+
+*/
+
+class dnsbeEppRegistrarInfoRequest extends eppRequest {
+
+    /**
+     * euridEppCreateContactRequest constructor.
+     * @throws eppException
+     */
+    function __construct() {
+        parent::__construct();
+        $info = $this->createElement('info');
+        $el = $this->createElement('registrar:info');
+        $info->appendChild($el);
+        $this->getCommand()->appendChild($info);
+    }
+
+}

--- a/Protocols/EPP/eppExtensions/registrar-1.0/eppResponses/dnsbeEppRegistrarInfoResponse.php
+++ b/Protocols/EPP/eppExtensions/registrar-1.0/eppResponses/dnsbeEppRegistrarInfoResponse.php
@@ -1,0 +1,23 @@
+<?php
+namespace Metaregistrar\EPP;
+/**
+ * Class euridEppRegistrarInfoResponse
+ * @package Metaregistrar\EPP
+ *
+ */
+class dnsbeEppRegistrarInfoResponse extends eppResponse {
+
+    function __construct() {
+        parent::__construct();
+    }
+
+    public function getBalance() {
+        $xpath = $this->xPath();
+        $result = $xpath->query('//dnssi:balance');
+        if ($result->length > 0) {
+            return $result->item(0)->nodeValue;
+        } else {
+            return null;
+        }
+    }
+}

--- a/Protocols/EPP/eppExtensions/registrar-1.0/eppResponses/dnsbeEppRegistrarInfoResponse.php
+++ b/Protocols/EPP/eppExtensions/registrar-1.0/eppResponses/dnsbeEppRegistrarInfoResponse.php
@@ -11,13 +11,34 @@ class dnsbeEppRegistrarInfoResponse extends eppResponse {
         parent::__construct();
     }
 
-    public function getBalance() {
+    public function getAmountAvailable() {
         $xpath = $this->xPath();
-        $result = $xpath->query('//dnssi:balance');
+        $result = $xpath->query('//dnsbe:amountAvailable');
         if ($result->length > 0) {
             return $result->item(0)->nodeValue;
         } else {
             return null;
         }
     }
+
+    public function getHitPoints() {
+        $xpath = $this->xPath();
+        $result = $xpath->query('//dnsbe:nbrHitPoints');
+        if ($result->length > 0) {
+            return $result->item(0)->nodeValue;
+        } else {
+            return null;
+        }
+    }
+
+    public function getMaxHitPoints() {
+        $xpath = $this->xPath();
+        $result = $xpath->query('//dnsbe:maxNbrHitPoints');
+        if ($result->length > 0) {
+            return $result->item(0)->nodeValue;
+        } else {
+            return null;
+        }
+    }
+
 }

--- a/Protocols/EPP/eppExtensions/registrar-1.0/includes.php
+++ b/Protocols/EPP/eppExtensions/registrar-1.0/includes.php
@@ -3,10 +3,14 @@ $this->addExtension('registrar', 'http://www.arnes.si/xml/epp/registrar-1.0');
 
 include_once(dirname(__FILE__) . '/eppRequests/siEppRegistrarInfoRequest.php');
 include_once(dirname(__FILE__) . '/eppResponses/siEppRegistrarInfoResponse.php');
+
 $this->addCommandResponse('Metaregistrar\EPP\siEppRegistrarInfoRequest', 'Metaregistrar\EPP\siEppRegistrarInfoResponse');
+
+$this->addExtension('registrar', 'http://www.dns.be/xml/epp/registrar-1.0');
 
 include_once(dirname(__FILE__) . '/eppRequests/dnsbeEppRegistrarInfoRequest.php');
 include_once(dirname(__FILE__) . '/eppResponses/dnsbeEppRegistrarInfoResponse.php');
+
 $this->addCommandResponse('Metaregistrar\EPP\dnsbeEppRegistrarInfoRequest', 'Metaregistrar\EPP\dnsbeEppRegistrarInfoResponse');
 
 

--- a/Protocols/EPP/eppExtensions/registrar-1.0/includes.php
+++ b/Protocols/EPP/eppExtensions/registrar-1.0/includes.php
@@ -3,7 +3,11 @@ $this->addExtension('registrar', 'http://www.arnes.si/xml/epp/registrar-1.0');
 
 include_once(dirname(__FILE__) . '/eppRequests/siEppRegistrarInfoRequest.php');
 include_once(dirname(__FILE__) . '/eppResponses/siEppRegistrarInfoResponse.php');
-
 $this->addCommandResponse('Metaregistrar\EPP\siEppRegistrarInfoRequest', 'Metaregistrar\EPP\siEppRegistrarInfoResponse');
+
+include_once(dirname(__FILE__) . '/eppRequests/dnsbeEppRegistrarInfoRequest.php');
+include_once(dirname(__FILE__) . '/eppResponses/dnsbeEppRegistrarInfoResponse.php');
+$this->addCommandResponse('Metaregistrar\EPP\dnsbeEppRegistrarInfoRequest', 'Metaregistrar\EPP\dnsbeEppRegistrarInfoResponse');
+
 
 

--- a/Registries/dnsbeEppConnection/eppConnection.php
+++ b/Registries/dnsbeEppConnection/eppConnection.php
@@ -9,7 +9,7 @@ class dnsbeEppConnection extends eppConnection {
 
         #parent::addExtension('keygroup','http://www.dns.be/xml/epp/keygroup-1.0');
         parent::useExtension('nsgroup-1.0');
-        parent::addExtension('registrar', 'http://www.dns.be/xml/epp/registrar-1.0');
+        parent::useExtension('registrar-1.0');
         parent::useExtension('dnsbe-1.0');
         parent::enableDnssec();
     }


### PR DESCRIPTION
Added the Registrar:info request (and response) for DNS.be. With this command the amount available, the current hitpoints and the maximum hitpoints can be retrieved from DNS.be.

No tests added, but tested in a project that communicates with the DNS.be EPP servers.