### PR TITLE
Better and tweakable readsleep settings

### DIFF
--- a/Protocols/EPP/eppConnection.php
+++ b/Protocols/EPP/eppConnection.php
@@ -437,6 +437,79 @@ class eppConnection {
     }
 
     /**
+     * Enable the readsleep functionality
+     * @var boolean
+     */
+    private $enableReadSleep = true;
+
+    /**
+     * The initial wait time in microseconds between read attempts
+     * @var integer
+     */
+    private $readSleepTimeInitialValue = 100;
+
+    /**
+     * The maximum time between read attempts in microseconds
+     * @var integer
+     */
+    private $readSleepTimeLimit = 100000;
+
+    /**
+     * When using the readsleep incrementor, increment the sleep time with incrementor value 1 until the
+     * the sleep time exceeds this value is exceeded then switch to the second incrementor value
+     * @var integer
+     */
+    private $readSleepTimeIncrementorLimit = 10000;
+
+    /**
+     * Enable the read sleep incrementor
+     * @var boolean
+     */
+    private $readSleepTimeIncrementEnabled = true;
+
+    /**
+     * The initial incrementor value
+     * @var integer
+     */
+    private $readSleepTimeIncrementor1 = 1000;
+
+    /**
+     * The second incrementor value
+     * @var integer
+     */
+    private $readSleepTimeIncrementor2 = 100;
+
+    /**
+     * Allows the ability turn off or tweak the response read timings.
+     * Disabling the readSleep will result in high CPU usage when waiting for a response from the epp server
+     *
+     * @param boolean $enableReadSleep
+     * @param boolean $incrementorEnabled
+     * @param integer  $initialReadSleepTime
+     * @param integer  $limit
+     * @param integer  $readSleepTimeIncrementorLimit
+     * @param integer  $incrementor1
+     * @param integer  $incrementor2
+     */
+    public function setReadTimings(
+        $enableReadSleep = true,
+        $incrementorEnabled = true,
+        $initialReadSleepTime = 100,
+        $limit = 100000,
+        $readSleepTimeIncrementorLimit = 10000,
+        $incrementor1 = 1000,
+        $incrementor2 = 100
+    ) {
+        $this->enableReadSleep = $enableReadSleep;
+        $this->readSleepTimeInitialValue = $initialReadSleepTime;
+        $this->readSleepTimeLimit = $limit;
+        $this->readSleepTimeIncrementorLimit = $readSleepTimeIncrementorLimit;
+        $this->readSleepTimeIncrementEnabled = $incrementorEnabled;
+        $this->readSleepTimeIncrementor1 = $incrementor1;
+        $this->readSleepTimeIncrementor2 = $incrementor2;
+    }
+
+    /**
      * This will read 1 response from the connection if there is one
      * @param boolean $nonBlocking to prevent the blocking of the thread in case there is nothing to read and not wait for the timeout
      * @return string
@@ -462,20 +535,38 @@ class eppConnection {
                 $readLength = 4;
                 //$readbuffer = "";
                 $read = "";
+                $useSleep = $this->enableReadSleep;
+                $readSleepTime = $this->readSleepTimeInitialValue;
+                $readSleepTimeLimit = $this->readSleepTimeLimit;
+                $readSleepTimeIncrementorLimit = $this->readSleepTimeIncrementorLimit;
+                $readSleepTimeIncrementEnabled = $this->readSleepTimeIncrementEnabled;
+                $readSleepTimeIncrementor1 = $this->readSleepTimeIncrementor1;
+                $readSleepTimeIncrementor2 = $this->readSleepTimeIncrementor2;
+//                $loops = 0;
                 while ($readLength > 0) {
+//                    $loops++;
                     if ($readbuffer = fread($this->connection, $readLength)) {
                         $readLength = $readLength - strlen($readbuffer);
                         $read .= $readbuffer;
                         $time = time() + $this->timeout;
-                    }
-                    if (strlen($readbuffer)==0) {
-                        usleep(100);
+                    } elseif ($useSleep) {
+                        usleep($readSleepTime);
+                        if ($readSleepTimeIncrementEnabled) {
+                            if ($readSleepTime < $readSleepTimeLimit) {
+                                if ($readSleepTime > $readSleepTimeIncrementorLimit) {
+                                    $readSleepTime += $readSleepTimeIncrementor2;
+                                } else {
+                                    $readSleepTime += $readSleepTimeIncrementor1;
+                                }
+                            }
+                        }
                     }
                     //Check if timeout occured
                     if (time() >= $time) {
                         return false;
                     }
                 }
+                //$this->writeLog("Used $loops loops to read initial 4 bytes","READ");
                 //$this->writeLog("Read 4 bytes for integer. (read: " . strlen($read) . "):$read","READ");
                 $length = $this->readInteger($read) - 4;
                 //$this->writeLog("Reading next: $length bytes","READ");


### PR DESCRIPTION
Allows the ability to turn the read wait time off or tweak the settings for your own system.

I benchmarked this against a local EPP server. Added a 1 second delay to each request (server side) to simulate longer response times to trigger the cpu usage issue.

**_For reviewer:_** Please review, run tests and check if this works properly. I have benchmarked and tested this manually but perhaps your unit tests might reveal some issues. 

## The benchmarking data:

Lower loops = lower cpu usage  = better

### no usleep
	CPU: 		99.9%
	Hello Loops:	1716
	Login Loops:	1528655
	Poll Loops:	1477121
	Logout Loops:	1361825
	Time taken:	3.444s

### current (master) sleep at 100 microseconds
	CPU:		4.1%
	Hello Loops:	9
	Login Loops:	8446
	Poll Loops:	8654
	Logout Loops:	8483
	Time taken:	3.430s
### current but longer sleep	 (1ms)
	CPU:		2.4%
	Hello Loops:	3
	Login Loops:	933
	Poll Loops:	884
	Logout Loops:	868
	Time taken:	3.459s

### this new branch
	CPU:		0.2%
	Hello Loops:	3
	Login Loops:	80
	Poll Loops:	80
	Logout Loops:	80
	Time taken: 3.444s

### This new branch but set Incrementor limit to 50000
	CPU:		0.2%
	Hello Loops:	3
	Login Loops:	47
	Poll Loops: 	47
	Logout Loops:	47
	Time taken:	3.529s