### PR TITLE
Remove usage of deprecated curly braces syntax to access string offsets

### DIFF
--- a/Protocols/EPP/eppData/eppContact.php
+++ b/Protocols/EPP/eppData/eppContact.php
@@ -239,7 +239,7 @@ class eppContact {
         if (!strlen($number)) {
             return null;
         }
-        if ($number{0} != '+') {
+        if ($number[0] != '+') {
             throw new eppException('Phone number ' . $number . ' is not valid for EPP. Valid format is +cc.nnnnnnnnnnn');
         }
         if (strpos($number, '.') === false) {

--- a/Protocols/EPP/eppData/eppIDNA.php
+++ b/Protocols/EPP/eppData/eppIDNA.php
@@ -389,7 +389,7 @@ class eppIDNA {
         $delim_pos = strrpos($encoded, '-');
         if ($delim_pos > self::byteLength($this->_punycode_prefix)) {
             for ($k = self::byteLength($this->_punycode_prefix); $k < $delim_pos; ++$k) {
-                $decoded[] = ord($encoded{$k});
+                $decoded[] = ord($encoded[$k]);
             }
         }
         $deco_len = count($decoded);
@@ -403,7 +403,7 @@ class eppIDNA {
 
         for ($enco_idx = ($delim_pos) ? ($delim_pos + 1) : 0; $enco_idx < $enco_len; ++$deco_len) {
             for ($old_idx = $idx, $w = 1, $k = $this->_base; 1; $k += $this->_base) {
-                $digit = $this->_decode_digit($encoded{$enco_idx++});
+                $digit = $this->_decode_digit($encoded[$enco_idx++]);
                 $idx += $digit * $w;
                 $t = ($k <= $bias) ? $this->_tmin :
                     (($k >= $bias + $this->_tmax) ? $this->_tmax : ($k - $bias));
@@ -785,7 +785,7 @@ class eppIDNA {
         $mode = 'next';
         $test = 'none';
         for ($k = 0; $k < $inp_len; ++$k) {
-            $v = ord($input{$k}); // Extract byte from input string
+            $v = ord($input[$k]); // Extract byte from input string
             if ($v < 128) { // We found an ASCII char - put into stirng as is
                 $output[$out_len] = $v;
                 ++$out_len;
@@ -913,7 +913,7 @@ class eppIDNA {
                 $out_len++;
                 $output[$out_len] = 0;
             }
-            $output[$out_len] += ord($input{$i}) << (8 * (3 - ($i % 4)));
+            $output[$out_len] += ord($input[$i]) << (8 * (3 - ($i % 4)));
         }
         return $output;
     }

--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppResponses/atEppResponseTrait.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppResponses/atEppResponseTrait.php
@@ -186,9 +186,9 @@ trait atEppResponseTrait
 
     public function Success() {
         $resultcode = $this->getResultCode();
-        $success = ($resultcode{0} == '1');
+        $success = ($resultcode[0] == '1');
         if (!$success) {
-            switch ($resultcode{1}) {
+            switch ($resultcode[1]) {
                 case '0':
                     $this->setProblemtype('syntax');
                     break;

--- a/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/eppResponses/sidnEppResponse.php
+++ b/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/eppResponses/sidnEppResponse.php
@@ -10,9 +10,9 @@ class sidnEppResponse extends eppResponse {
         $xpath = $this->xPath();
         $result = $xpath->query('/epp:epp/epp:response/epp:result/@code');
         $resultcode = $result->item(0)->nodeValue;
-        $success = ($resultcode{0} == '1');
+        $success = ($resultcode[0] == '1');
         if (!$success) {
-            switch ($resultcode{1}) {
+            switch ($resultcode[1]) {
                 case '0':
                     $this->setProblemtype('syntax');
                     break;

--- a/Protocols/EPP/eppResponses/eppResponse.php
+++ b/Protocols/EPP/eppResponses/eppResponse.php
@@ -123,9 +123,9 @@ class eppResponse extends \DOMDocument {
      */
     public function Success() {
         $resultcode = $this->getResultCode();
-        $success = ($resultcode{0} == '1');
+        $success = ($resultcode[0] == '1');
         if (!$success) {
-            switch ($resultcode{1}) {
+            switch ($resultcode[1]) {
                 case '0':
                     $this->setProblemtype('syntax');
                     break;


### PR DESCRIPTION
Fixes deprecation warning on PHP 7.4

`PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in ...`

https://www.php.net/manual/de/migration74.deprecated.php#migration74.deprecated.core.array-string-access-curly-brace