### PR TITLE
Norid: Fix issue with implicit renew

### DIFF
--- a/Protocols/EPP/eppExtensions/no-ext-domain-1.1/eppRequests/noridEppTransferRequest.php
+++ b/Protocols/EPP/eppExtensions/no-ext-domain-1.1/eppRequests/noridEppTransferRequest.php
@@ -38,16 +38,16 @@ class noridEppTransferRequest extends eppTransferRequest {
 
         $this->domainobject->appendChild($this->createElement('domain:name', $domain->getDomainname()));
 
-        if (strlen($domain->getAuthorisationCode())) {
-            $authinfo = $this->createElement('domain:authInfo');
-            $authinfo->appendChild($this->createElement('domain:pw', $domain->getAuthorisationCode()));
-            $this->domainobject->appendChild($authinfo);
-        }
-
         if ($domain->getPeriod()) {
             $domainperiod = $this->createElement('domain:period', $domain->getPeriod());
             $domainperiod->setAttribute('unit', eppDomain::DOMAIN_PERIOD_UNIT_Y);
             $this->domainobject->appendChild($domainperiod);
+        }
+
+        if (strlen($domain->getAuthorisationCode())) {
+            $authinfo = $this->createElement('domain:authInfo');
+            $authinfo->appendChild($this->createElement('domain:pw', $domain->getAuthorisationCode()));
+            $this->domainobject->appendChild($authinfo);
         }
 
         $transfer->appendChild($this->domainobject);


### PR DESCRIPTION
Fix issue where domain:authInfo and domain:period elements are ordered wrongly, causing `<transfer op="execute" />` commands to fail when trying to implicitly renew.

### Error message

```shell
Parse error at line [2], column [1871]: Element '{urn:ietf:params:xml:ns:domain-1.0}period': This element is not expected.
```

### Reproduce

To reproduce the issue, you'll need to try moving a domain that has expired. The error you'll get is:

```shell
Domain [vg.no] expired 2020-03-18. The transfer command must include a renewal period.
```

@alexrsagen are you able to recreate this issue?

**PS**: First time using this library, the EPP protocol is also quite new for me. Expect me to misunderstand stuff 😅