### PR TITLE
fixed send big data

### DIFF
--- a/Protocols/EPP/eppConnection.php
+++ b/Protocols/EPP/eppConnection.php
@@ -353,7 +353,7 @@ class eppConnection {
         }
         $this->connection = stream_socket_client($this->hostname.':'.$this->port, $errno, $errstr, $this->timeout, STREAM_CLIENT_CONNECT, $context);
         if (is_resource($this->connection)) {
-            stream_set_blocking($this->connection, false);
+            stream_set_blocking($this->connection, true);
             stream_set_timeout($this->connection, $this->timeout);
             if ($errno == 0) {
                 $meta = stream_get_meta_data($this->connection);


### PR DESCRIPTION
Teleinfo is a Chinese VSP that provides real-name verification. The real-name verification needs to provide a certificate picture. Most of the pictures are above 100K. When the connection method is set to non-blocking, a single fwrite action cannot send all data, so I will connect Changing the mode to blocking mode may affect performance, but it can ensure that all data is sent correctly. I have tested that uploading more than 1M can also succeed.