### PR TITLE
Update eppContact.php

### DIFF
--- a/Protocols/EPP/eppData/eppContact.php
+++ b/Protocols/EPP/eppData/eppContact.php
@@ -178,7 +178,7 @@ class eppContact {
      */
 
     public function setPassword($password) {
-        if ($password) {
+        if ($password !== null) {
             $this->password = htmlspecialchars($password, ENT_COMPAT, "UTF-8");
         } else {
             $this->password = null;


### PR DESCRIPTION
We fixed an issue with an empty contact password with openprovider EPP. 
Error 2003: Required parameter missing (Element '{urn:ietf:params:xml:ns:contact-1.0}create': Missing child element(s). Expected is ( {urn:ietf:params:xml:ns:contact-1.0}authInfo ).)

If the contact password is set to ‘’ or null, the xml removed this part:
<contact:authInfo>\n
    <contact:pw/>\n
</contact:authInfo>\n

This part is needed for the validation for openprovider EPP. If we fill the password, a provider like SIDN will ignore the password and continue, but openprovider chooses to throw an error:
Error 2102: Unimplemented option (Contact password is not supported)

Our changes gives us three option for the contact xml:
1.	If password is set, password is filled
2.	If password is set to ‘’, the xml is extended with the authInfo data
3.	If password is to to null, the xml ignores the extending of authInfo data.