### PR TITLE
Use organisationName as name in SIDN EPP and set legalForm

### DIFF
--- a/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/eppRequests/sidnEppContactPostalInfo.php
+++ b/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/eppRequests/sidnEppContactPostalInfo.php
@@ -1,0 +1,39 @@
+<?php
+namespace Metaregistrar\EPP;
+/*
+ *
+ * The EPP org field is intended for the name of the organisation. In the SIDN EPP implementation the org field
+ * is being used as a organisational department and not the organisation itself.
+ *
+ * The name should contain the name of the organisation and the legalForm SIDN EPP extension shouldn't be a natural person.
+ *
+ */
+class sidnEppContactPostalInfo extends eppContactPostalInfo {
+    private $legalForm;
+
+    /**
+     *
+     * @param string $name
+     * @param string $city
+     * @param string $countrycode
+     * @param string $organisationName
+     * @param string $street
+     * @param string $province
+     * @param string $zipcode
+     * @param string $type POSTAL_TYPE_LOC or POSTAL_TYPE_INT
+     */
+    public function __construct($name = null, $city = null, $countrycode = null, $organisationName = null, $street = null, $province = null, $zipcode = null, $type = eppContact::TYPE_AUTO) {
+        if (!empty($organisationName)) {
+            $name = $organisationName;
+            $this->legalForm = 'ANDERS';
+        } else {
+            $this->legalForm = 'PERSOON';
+        }
+
+        parent::__construct($name, $city, $countrycode, null, $street, $province, $zipcode, $type);
+    }
+
+    public function getLegalForm() {
+        return $this->legalForm;
+    }
+}

--- a/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/eppRequests/sidnEppCreateContactRequest.php
+++ b/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/eppRequests/sidnEppCreateContactRequest.php
@@ -14,7 +14,6 @@ namespace Metaregistrar\EPP;
  */
 class sidnEppCreateContactRequest extends eppCreateContactRequest {
 
-
     function __construct($createinfo) {
         parent::__construct($createinfo);
         if ($createinfo instanceof eppContact) {
@@ -26,18 +25,12 @@ class sidnEppCreateContactRequest extends eppCreateContactRequest {
     private function addSidnExtension(eppContact $contact) {
         $postal = $contact->getPostalInfo(0);
 
-        if (strlen($postal->getOrganisationName())) {
-            $legalform = 'ANDERS';
-        } else {
-            $legalform= 'PERSOON';
-        }
         $sidnext = $this->createElement('sidn-ext-epp:ext');
         $create = $this->createElement('sidn-ext-epp:create');
         $contact = $this->createElement('sidn-ext-epp:contact');
-        $contact->appendChild($this->createElement('sidn-ext-epp:legalForm', $legalform));
+        $contact->appendChild($this->createElement('sidn-ext-epp:legalForm', $postal->getLegalForm()));
         $create->appendChild($contact);
         $sidnext->appendChild($create);
         $this->getExtension()->appendChild($sidnext);
-
     }
 }

--- a/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/includes.php
+++ b/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/includes.php
@@ -3,6 +3,10 @@ $this->addExtension('sidn-ext-epp', 'http://rxsd.domain-registry.nl/sidn-ext-epp
 
 include_once(dirname(__FILE__) . '/eppResponses/sidnEppResponse.php');
 
+// Org field is used by SIDN as organisational department
+include_once(dirname(__FILE__) . '/eppRequests/sidnEppContactPostalInfo.php');
+$this->addCommandResponse('Metaregistrar\EPP\sidnEppContactPostalInfo', 'Metaregistrar\EPP\eppContactPostalInfo');
+
 // Create contact with additional parameters
 include_once(dirname(__FILE__) . '/eppRequests/sidnEppCreateContactRequest.php');
 $this->addCommandResponse('Metaregistrar\EPP\sidnEppCreateContactRequest', 'Metaregistrar\EPP\eppCreateContactResponse');
@@ -10,7 +14,6 @@ $this->addCommandResponse('Metaregistrar\EPP\sidnEppCreateContactRequest', 'Meta
 // Renew domain name with renew extension (this is not an extension????)
 include_once(dirname(__FILE__) . '/eppRequests/sidnEppRenewRequest.php');
 $this->addCommandResponse('Metaregistrar\EPP\sidnEppRenewRequest', 'Metaregistrar\EPP\eppRenewResponse');
-
 
 include_once(dirname(__FILE__) . '/eppRequests/sidnEppPollRequest.php');
 include_once(dirname(__FILE__) . '/eppResponses/sidnEppPollResponse.php');


### PR DESCRIPTION
The EPP org field is intended for the name of the organisation. In the SIDN EPP implementation the org field is being used as a organisational department and not the organisation itself.

The name of the contact should contain the name of the organisation and the legalForm SIDN EPP extension shouldn't be a natural person. You can of course put in the same value in name and organisationName but why fill the department field with invalid/unneeded data.