### PR TITLE
Added override to prevent empty elements in DOM

### DIFF
--- a/Protocols/EPP/eppExtensions/verisign/eppRequests/verisignEppCreateContactRequest.php
+++ b/Protocols/EPP/eppExtensions/verisign/eppRequests/verisignEppCreateContactRequest.php
@@ -15,4 +15,59 @@ class verisignEppCreateContactRequest extends eppCreateContactRequest {
         $this->addNamestore();
         $this->addSessionId();
     }
+
+    /**
+     * Set the postalinfo information in the contact
+     * 
+     * Overrides the setPostalInfo function in the parent.
+     * Verisign doesn't expect empty values to be sent as part of the XML request
+     * and will actually respond with an XML syntax error. This function will
+     * prevent empty eppContactPostalInfo fields from being added to the XML DOM request.
+     * 
+     * @param eppContactPostalInfo $eppContactPostalInfo
+     * @throws eppException
+     */
+
+    public function setPostalInfo(eppContactPostalInfo $eppContactPostalInfo) {
+        $postalInfoElement = $this->createElement('contact:postalInfo');
+        if (!$eppContactPostalInfo instanceof eppContactPostalInfo) {
+            throw new eppException('PostalInfo must be filled on eppCreateContact request');
+        }
+        if ($eppContactPostalInfo->getType() == eppContact::TYPE_AUTO) {
+            // If all fields are ascii, type = int (international) else type = loc (localization)
+            if ((self::isAscii($eppContactPostalInfo->getName())) && (self::isAscii($eppContactPostalInfo->getOrganisationName())) && (self::isAscii($eppContactPostalInfo->getStreet(0)))) {
+                $eppContactPostalInfo->setType(eppContact::TYPE_INT);
+            } else {
+                $eppContactPostalInfo->setType(eppContact::TYPE_LOC);
+            }
+        }
+        $postalInfoElement->setAttribute('type', $eppContactPostalInfo->getType());
+        if ($eppContactPostalInfo->getName()) {
+            $postalInfoElement->appendChild($this->createElement('contact:name', $eppContactPostalInfo->getName()));
+        }
+        if ($eppContactPostalInfo->getOrganisationName()) {
+            $postalInfoElement->appendChild($this->createElement('contact:org', $postal->getOrganisationName()));
+        }
+        $addressElement = $this->createElement('contact:addr');
+        $count = $eppContactPostalInfo->getStreetCount();
+        for ($i = 0; $i < $count; $i++) {
+            $addressElement->appendChild($this->createElement('contact:street', $eppContactPostalInfo->getStreet($i)));
+        }
+        if ($eppContactPostalInfo->getCity()) {
+            $addressElement->appendChild($this->createElement('contact:city', $eppContactPostalInfo->getCity()));
+        }
+        if ($eppContactPostalInfo->getProvince()) {
+            $addressElement->appendChild($this->createElement('contact:sp', $eppContactPostalInfo->getProvince()));
+        }
+        if ($eppContactPostalInfo->getZipcode()) {
+            $addressElement->appendChild($this->createElement('contact:pc', $eppContactPostalInfo->getZipcode()));
+        }
+        if ($eppContactPostalInfo->getCountrycode()) {
+            $addressElement->appendChild($this->createElement('contact:cc', $eppContactPostalInfo->getCountrycode()));
+        }
+        if ($addressElement->hasChildNodes()) {
+            $postalInfoElement->appendChild($addressElement);
+        }
+        $this->contactobject->appendChild($postalInfoElement);
+    }
 }


### PR DESCRIPTION
The Verisign registry only requires the Contact ID, Postal Info, and Auth Info fields to be submitted in the EPP request when creating a contact. 

Currently, the Verisign extension has an EPP request for creating a new contact that extends the base `eppCreateContactRequest` class. I've added a function to the `verisignEppCreateContactRequest` class to override the `setPostalInfo` function in it's parent class. The function will prevent empty eppContactPostalInfo fields from being added to the XML DOM request.

I wasn't sure if this was a change that could be made in the parent classes function, since I only have access to test on the Verisign registry.

Please let me know if you'd like to see tests for this. I was trying to use XPath to query the XML request object but couldn't seem to get it to work.

## Changelog
* Added override function to prevent empty postal info elements in the create contact DOM request to the Verisign registry