### PR TITLE
Fixed an invalid reference to a variable name

### DIFF
--- a/Protocols/EPP/eppExtensions/verisign/eppRequests/verisignEppCreateContactRequest.php
+++ b/Protocols/EPP/eppExtensions/verisign/eppRequests/verisignEppCreateContactRequest.php
@@ -46,7 +46,7 @@ class verisignEppCreateContactRequest extends eppCreateContactRequest {
             $postalInfoElement->appendChild($this->createElement('contact:name', $eppContactPostalInfo->getName()));
         }
         if ($eppContactPostalInfo->getOrganisationName()) {
-            $postalInfoElement->appendChild($this->createElement('contact:org', $postal->getOrganisationName()));
+            $postalInfoElement->appendChild($this->createElement('contact:org', $eppContactPostalInfo->getOrganisationName()));
         }
         $addressElement = $this->createElement('contact:addr');
         $count = $eppContactPostalInfo->getStreetCount();


### PR DESCRIPTION
Fixed an issue where an invalid variable name was being referenced when creating a contact create request for the Verisign registry. The issue was introduced in PR [299](https://github.com/metaregistrar/php-epp-client/pull/299).

Sorry for this oversight, and thanks for being quick about merging.