### PR TITLE
Added URL parameter to DNS.be Request Authorization Code

### DIFF
--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppRequests/dnsbeEppAuthcodeRequest.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppRequests/dnsbeEppAuthcodeRequest.php
@@ -20,11 +20,11 @@ namespace Metaregistrar\EPP;
 
 */
 class dnsbeEppAuthcodeRequest extends eppRequest {
-    function __construct($domainname) {
+    function __construct($domainname,$url=null) {
         parent::__construct();
         if (is_string($domainname)) {
             if (strlen($domainname) > 0) {
-                $this->addDnsbeExtension($domainname);
+                $this->addDnsbeExtension($domainname,$url);
             } else {
                 throw new eppException("Domain name length may not be 0 on eppAuthcodeRequest");
             }
@@ -34,14 +34,16 @@ class dnsbeEppAuthcodeRequest extends eppRequest {
 
     }
 
-    private function addDnsbeExtension($domainname) {
+    private function addDnsbeExtension($domainname,$url=null) {
         $this->addExtension('xmlns:dnsbe', 'http://www.dns.be/xml/epp/dnsbe-1.0');
         $ext = $this->createElement('extension');
         $dnsext = $this->createElement('dnsbe:ext');
         $command = $this->createElement('dnsbe:command');
         $authcode = $this->createElement('dnsbe:requestAuthCode');
         $authcode->appendChild($this->createElement('dnsbe:domainName', $domainname));
-        $authcode->appendChild($this->createElement('dnsbe:url', 'http://www.metaregistrar.com/transfer?domainname=' . $domainname));
+        if($url!==null && preg_match("/^https?:\/\//",$url)) {
+           $authcode->appendChild($this->createElement('dnsbe:url', $url));
+        }
         $command->appendChild($authcode);
         $dnsext->appendChild($command);
         $ext->appendChild($dnsext);

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppRequests/dnsbeEppCheckDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppRequests/dnsbeEppCheckDomainRequest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Metaregistrar\EPP;
+/*
+<?xml version="1.0" encoding="UTF-8"?>
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xmlns:epp="urn:ietf:params:xml:ns:epp-1.0"
+     xmlns:domain="urn:ietf:params:xml:ns:domain-1.0"
+     xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd
+                urn:ietf:params:xml:ns:domain-1.0 domain-1.0.xsd">
+<command>
+  <check>
+     <domain:check>
+       <domain:name>semaphore.be</domain:name>
+       <domain:name>greatdomain.be</domain:name>
+       <domain:name>test-v2.be</domain:name>
+       <domain:name>dns-domain-22.be</domain:name>
+       <domain:name>dnà</domain:name>
+       <domain:name>xn--belgi-rsa</domain:name>
+       <domain:name>$$$</domain:name>
+       <domain:name>belgië</domain:name>
+    </domain:check>
+  </check>
+<extension>
+  <dnsbe:ext xmlns:dnsbe="http://www.dns.be/xml/epp/dnsbe-1.0">
+    <dnsbe:check>
+      <dnsbe:domain version="2.0"/>
+    </dnsbe:check>
+  </dnsbe:ext>
+</extension>
+  <clTRID>clientref-00029</clTRID>
+</command>
+</epp>
+*/
+
+class dnsbeEppCheckDomainRequest extends eppCheckDomainRequest {
+   function __construct($checkrequest, $namespacesinroot = true) {
+      parent::__construct($checkrequest, $namespacesinroot = true);
+      $this->addDnsbeExtension();
+   }
+
+   private function addDnsbeExtension() {
+      $this->addExtension('xmlns:dnsbe', 'http://www.dns.be/xml/epp/dnsbe-1.0');
+      $ext = $this->createElement('extension');
+      $dnsext = $this->createElement('dnsbe:ext');
+      $dnsext->setAttribute("xmlns:dnsbe","http://www.dns.be/xml/epp/dnsbe-1.0");
+      $check = $this->createElement('dnsbe:check');
+      $version = $this->createElement('dnsbe:domain');
+      $version->setAttribute("version","2.0");
+      $check->appendChild($version);
+      $dnsext->appendChild($check);
+      $ext->appendChild($dnsext);
+      $this->getCommand()->appendChild($ext);
+      $this->addSessionId();
+   }
+
+}

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppRequests/dnsbeEppCreateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppRequests/dnsbeEppCreateDomainRequest.php
@@ -15,4 +15,24 @@ class dnsbeEppCreateDomainRequest extends eppCreateDomainRequest {
         $this->addSessionId();
     }
 
+   public function addnsgroup($nsgroup) {
+      $this->addExtension('xmlns:dnsbe', 'http://www.dns.be/xml/epp/dnsbe-1.0');
+      $ext = $this->createElement('extension');
+      $dnsext = $this->createElement('dnsbe:ext');
+      $create = $this->createElement('dnsbe:create');
+      $domain = $this->createElement('dnsbe:domain');
+      if(is_array($nsgroup)){
+         foreach ($nsgroup as $nsgroupname){
+            $domain->appendChild($this->createElement('dnsbe:nsgroup', $nsgroupname));
+         }
+      }
+      else {
+         $domain->appendChild($this->createElement('dnsbe:nsgroup', $nsgroup));
+      }
+      $create->appendChild($domain);
+      $dnsext->appendChild($create);
+      $ext->appendChild($dnsext);
+      $this->getCommand()->appendChild($ext);
+      $this->addSessionId();
+   }
 }

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppCheckDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppCheckDomainResponse.php
@@ -1,0 +1,10 @@
+<?php
+namespace Metaregistrar\EPP;
+class dnsbeEppCheckDomainResponse extends eppCheckDomainResponse {
+    function __construct() {
+        parent::__construct();
+    }
+
+
+
+}

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/includes.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/includes.php
@@ -44,3 +44,7 @@ $this->addCommandResponse('Metaregistrar\EPP\dnsbeEppReactivateDomainRequest', '
 include_once(dirname(__FILE__) . '/eppRequests/dnsbeEppInfoContactRequest.php');
 include_once(dirname(__FILE__) . '/eppResponses/dnsbeEppInfoContactResponse.php');
 $this->addCommandResponse('Metaregistrar\EPP\dnsbeEppInfoContactRequest', 'Metaregistrar\EPP\dnsbeEppInfoContactResponse');
+
+include_once(dirname(__FILE__) . '/eppRequests/dnsbeEppCheckDomainRequest.php');
+include_once(dirname(__FILE__) . '/eppResponses/dnsbeEppCheckDomainResponse.php');
+$this->addCommandResponse('Metaregistrar\EPP\dnsbeEppCheckDomainRequest', 'Metaregistrar\EPP\dnsbeEppCheckDomainResponse');


### PR DESCRIPTION
The URL used in DNS.be was hardcoded to a Metaregistrar URL.