### PR TITLE
Added possibility for PHP 8 in require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7",
+        "php": "^7|^8.0",
         "ext-dom": "*",
         "ext-libxml": "*"
     },


### PR DESCRIPTION
10 days ago a fix for PHP 8 had been merged into master. Although the package still fails to install due to mentioned version.