### PR TITLE
Remove optional null value

### DIFF
--- a/Protocols/EPP/eppConnection.php
+++ b/Protocols/EPP/eppConnection.php
@@ -1172,7 +1172,7 @@ class eppConnection {
      * @return array
      * @throws eppException
      */
-    static function loadSettings($directory = null, $settingsfile) {
+    static function loadSettings($directory, $settingsfile) {
         if ($directory) {
             $path = $directory . '/' . $settingsfile;
         } else {


### PR DESCRIPTION
As of PHP 8.0.0, passing mandatory arguments after optional arguments is deprecated. Therefore the directory parameter should (and is) always be passed to the loadSettings function.