### PR TITLE
Norid: Fix transfer with special chars in authinfo

### DIFF
--- a/Protocols/EPP/eppExtensions/no-ext-domain-1.1/eppRequests/noridEppTransferRequest.php
+++ b/Protocols/EPP/eppExtensions/no-ext-domain-1.1/eppRequests/noridEppTransferRequest.php
@@ -46,7 +46,8 @@ class noridEppTransferRequest extends eppTransferRequest {
 
         if (strlen($domain->getAuthorisationCode())) {
             $authinfo = $this->createElement('domain:authInfo');
-            $authinfo->appendChild($this->createElement('domain:pw', $domain->getAuthorisationCode()));
+            $pw = $authinfo->appendChild($this->createElement('domain:pw'));
+            $pw->appendChild($this->createCDATASection($domain->getAuthorisationCode()));
             $this->domainobject->appendChild($authinfo);
         }
 


### PR DESCRIPTION
Changed Norid transfer requests to use a CDATA element for authInfo:pw instead of a text node.