### PR TITLE
fix broken Arnes implementation

### DIFF
--- a/Protocols/EPP/eppExtensions/registrar-1.0/includes.php
+++ b/Protocols/EPP/eppExtensions/registrar-1.0/includes.php
@@ -1,17 +1,22 @@
 <?php
-$this->addExtension('registrar', 'http://www.arnes.si/xml/epp/registrar-1.0');
+$bt = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 2);
+$reflect = new ReflectionClass($bt[1]['object']);
 
-include_once(dirname(__FILE__) . '/eppRequests/siEppRegistrarInfoRequest.php');
-include_once(dirname(__FILE__) . '/eppResponses/siEppRegistrarInfoResponse.php');
+if ($reflect->getShortName() === 'siEppConnection') {
+    $this->addExtension('registrar', 'http://www.arnes.si/xml/epp/registrar-1.0');
 
-$this->addCommandResponse('Metaregistrar\EPP\siEppRegistrarInfoRequest', 'Metaregistrar\EPP\siEppRegistrarInfoResponse');
+    include_once(dirname(__FILE__) . '/eppRequests/siEppRegistrarInfoRequest.php');
+    include_once(dirname(__FILE__) . '/eppResponses/siEppRegistrarInfoResponse.php');
 
-$this->addExtension('registrar', 'http://www.dns.be/xml/epp/registrar-1.0');
+    $this->addCommandResponse('Metaregistrar\EPP\siEppRegistrarInfoRequest', 'Metaregistrar\EPP\siEppRegistrarInfoResponse');
+} else {
+    $this->addExtension('registrar', 'http://www.dns.be/xml/epp/registrar-1.0');
 
-include_once(dirname(__FILE__) . '/eppRequests/dnsbeEppRegistrarInfoRequest.php');
-include_once(dirname(__FILE__) . '/eppResponses/dnsbeEppRegistrarInfoResponse.php');
+    include_once(dirname(__FILE__) . '/eppRequests/dnsbeEppRegistrarInfoRequest.php');
+    include_once(dirname(__FILE__) . '/eppResponses/dnsbeEppRegistrarInfoResponse.php');
 
-$this->addCommandResponse('Metaregistrar\EPP\dnsbeEppRegistrarInfoRequest', 'Metaregistrar\EPP\dnsbeEppRegistrarInfoResponse');
+    $this->addCommandResponse('Metaregistrar\EPP\dnsbeEppRegistrarInfoRequest', 'Metaregistrar\EPP\dnsbeEppRegistrarInfoResponse');
 
+}
 
 


### PR DESCRIPTION
This one fixes Arnes implementation because BE registry broke it. They both use registrar-1.0 but have a different implementation. I haven't tested performance since reflection is being used to get info from where the extension was called. 