### PR TITLE
Fix deprecation warnings in PHP 8.1

### DIFF
--- a/Protocols/EPP/eppData/eppContact.php
+++ b/Protocols/EPP/eppData/eppContact.php
@@ -163,7 +163,7 @@ class eppContact {
 
     /**
      * Gets the email address
-     * @return string
+     * @return string|null
      */
     public function getEmail() {
         return $this->email;
@@ -205,7 +205,7 @@ class eppContact {
 
     /**
      * Gets the phone number
-     * @return string
+     * @return string|null
      */
     public function getVoice() {
         return $this->voice;

--- a/Protocols/EPP/eppData/eppContactPostalInfo.php
+++ b/Protocols/EPP/eppData/eppContactPostalInfo.php
@@ -33,7 +33,9 @@ class eppContactPostalInfo {
      * @param string $type POSTAL_TYPE_LOC or POSTAL_TYPE_INT
      */
     public function __construct($name = null, $city = null, $countrycode = null, $organisationName = null, $street = null, $province = null, $zipcode = null, $type = eppContact::TYPE_AUTO) {
-        $this->setName($name);
+        if (null !== $name) {
+            $this->setName($name);
+        }
         #
         # Street can be an array of max 3 streets, or a string with an address
         #

--- a/Protocols/EPP/eppData/eppContactPostalInfo.php
+++ b/Protocols/EPP/eppData/eppContactPostalInfo.php
@@ -192,7 +192,7 @@ class eppContactPostalInfo {
 
     /**
      * Gets the province
-     * @return string
+     * @return string|null
      */
     public function getProvince() {
         return $this->province;

--- a/Protocols/EPP/eppData/eppDomain.php
+++ b/Protocols/EPP/eppData/eppDomain.php
@@ -336,7 +336,7 @@ class eppDomain {
 
     /**
      *
-     * @return string
+     * @return string|null
      */
     public function getAuthorisationCode() {
         return $this->authorisationCode;

--- a/Protocols/EPP/eppData/eppHost.php
+++ b/Protocols/EPP/eppData/eppHost.php
@@ -56,7 +56,7 @@ class eppHost {
                 }
             }
         } else {
-            if (strlen($ipaddress)) {
+            if (is_string($ipaddress) && strlen($ipaddress)) {
                 $this->setIpAddress($ipaddress);
             }
         }
@@ -67,7 +67,7 @@ class eppHost {
                 }
             }
         } else {
-            if (strlen($hoststatus)) {
+            if (is_string($hoststatus) && strlen($hoststatus)) {
                 $this->setHostStatus($hoststatus);
             }
         }

--- a/Protocols/EPP/eppRequests/eppCreateDomainRequest.php
+++ b/Protocols/EPP/eppRequests/eppCreateDomainRequest.php
@@ -122,7 +122,7 @@ class eppCreateDomainRequest extends eppDomainRequest {
                 }
             }
         }
-        if (strlen($domain->getAuthorisationCode())) {
+        if (is_string($domain->getAuthorisationCode()) && strlen($domain->getAuthorisationCode())) {
             $authinfo = $this->createElement('domain:authInfo');
             if ($this->useCdata()) {
                 $pw = $authinfo->appendChild($this->createElement('domain:pw'));

--- a/Protocols/EPP/eppRequests/eppTransferRequest.php
+++ b/Protocols/EPP/eppRequests/eppTransferRequest.php
@@ -152,7 +152,7 @@ class eppTransferRequest extends eppRequest {
      * @param eppDomain $domain
      */
     private function addAuthcode($domain) {
-        if (strlen($domain->getAuthorisationCode())>0) {
+        if (is_string($domain->getAuthorisationCode()) && strlen($domain->getAuthorisationCode())>0) {
             $authinfo = $this->createElement('domain:authInfo');
             if ($this->useCdata()) {
                 $pw = $authinfo->appendChild($this->createElement('domain:pw'));
@@ -190,7 +190,7 @@ class eppTransferRequest extends eppRequest {
             $domainperiod->setAttribute('unit', eppDomain::DOMAIN_PERIOD_UNIT_Y);
             $this->domainobject->appendChild($domainperiod);
         }
-        if (strlen($domain->getAuthorisationCode())) {
+        if (is_string($domain->getAuthorisationCode()) && strlen($domain->getAuthorisationCode())) {
             $authinfo = $this->createElement('domain:authInfo');
             if ($this->useCdata()) {
                 $pw = $authinfo->appendChild($this->createElement('domain:pw'));

--- a/Protocols/EPP/eppRequests/eppUpdateContactRequest.php
+++ b/Protocols/EPP/eppRequests/eppUpdateContactRequest.php
@@ -115,7 +115,7 @@ class eppUpdateContactRequest extends eppContactRequest {
                 if (strlen($postal->getCity())) {
                     $postaladdr->appendChild($this->createElement('contact:city', $postal->getCity()));
                 }
-                if (strlen($postal->getProvince())) {
+                if (is_string($postal->getProvince()) && strlen($postal->getProvince())) {
                     $postaladdr->appendChild($this->createElement('contact:sp', $postal->getProvince()));
                 }
                 if (strlen($postal->getZipcode())) {
@@ -129,7 +129,7 @@ class eppUpdateContactRequest extends eppContactRequest {
             $element->appendChild($postalinfo);
         }
         // Mandatory field
-        if (strlen($contact->getVoice())) {
+        if (is_string($contact->getVoice()) && strlen($contact->getVoice())) {
             $element->appendChild($this->createElement('contact:voice', $contact->getVoice()));
         }
         // Optional field, may be empty
@@ -137,7 +137,7 @@ class eppUpdateContactRequest extends eppContactRequest {
             $element->appendChild($this->createElement('contact:fax', $contact->getFax()));
         }
         // Mandatory field
-        if (strlen($contact->getEmail())) {
+        if (is_string($contact->getEmail()) && strlen($contact->getEmail())) {
             $element->appendChild($this->createElement('contact:email', $contact->getEmail()));
         }
         // Optional field, may be empty

--- a/Protocols/EPP/eppRequests/eppUpdateDomainRequest.php
+++ b/Protocols/EPP/eppRequests/eppUpdateDomainRequest.php
@@ -95,14 +95,15 @@ class eppUpdateDomainRequest extends eppDomainRequest {
                 $this->addDomainStatus($element, $status);
             }
         }
-        if (strlen($domain->getAuthorisationCode())) {
+        $authcode = $domain->getAuthorisationCode();
+        if (is_string($authcode) && strlen($authcode)) {
             $authinfo = $this->createElement('domain:authInfo');
             if ($this->useCdata()) {
                 $pw = $this->createElement('domain:pw');
-                $pw->appendChild($this->createCDATASection($domain->getAuthorisationCode()));
+                $pw->appendChild($this->createCDATASection($authcode));
             }
             else {
-                $pw = $this->createElement('domain:pw',$domain->getAuthorisationCode());
+                $pw = $this->createElement('domain:pw',$authcode);
             }
             $authinfo->appendChild($pw);
             $element->appendChild($authinfo);

--- a/Protocols/EPP/eppResponses/eppResponse.php
+++ b/Protocols/EPP/eppResponses/eppResponse.php
@@ -203,7 +203,7 @@ class eppResponse extends \DOMDocument {
                 $errorstring .= '; ' . $id;
             }
             $resultreason = $this->getResultReason();
-            if (strlen($resultreason)) {
+            if (is_string($resultreason) && strlen($resultreason)) {
                 $errorstring .= ' (' . $resultreason . ')';
             }
             if ((is_array($this->exceptions)) && (count($this->exceptions)>0)) {

--- a/Protocols/EPP/eppResponses/eppResponse.php
+++ b/Protocols/EPP/eppResponses/eppResponse.php
@@ -109,6 +109,7 @@ class eppResponse extends \DOMDocument {
         return false;
     }
 
+    #[\ReturnTypeWillChange]
     public function saveXML(\DOMNode $node = NULL, $options = NULL) {
         return str_replace("\t", '  ', parent::saveXML($node, LIBXML_NOEMPTYTAG));
     }

--- a/Protocols/TMCH/tmchData/tmchClaimData.php
+++ b/Protocols/TMCH/tmchData/tmchClaimData.php
@@ -167,6 +167,7 @@ class tmchClaimData extends \DOMDocument {
      * @param null $options
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function saveXML(\DOMNode $node = null, $options = null) {
         return str_replace("\t", '  ', parent::saveXML($node, LIBXML_NOEMPTYTAG));
     }


### PR DESCRIPTION
This PR tackles at least some of the deprecation warnings which I noticed when using the package with PHP 8.1:

```
Deprecated: Return type of Metaregistrar\EPP\eppResponse::saveXML(?DOMNode $node = null, $options = null) should either be compatible with DOMDocument::saveXML(?DOMNode $node = null, int $options = 0): string|false, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated
Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated
```