### PR TITLE
Allow override of Natural Person setting in euridEppContact

### DIFF
--- a/Protocols/EPP/eppExtensions/contact-ext-1.3/eppData/euridEppContact.php
+++ b/Protocols/EPP/eppExtensions/contact-ext-1.3/eppData/euridEppContact.php
@@ -35,6 +35,7 @@ class euridEppContact extends eppContact {
     private $contactExtLang = 'en';
     private $contactExtVat  = null;
     private $countryOfCitizenship = null;
+    private $naturalPerson = null;
 
     public function __construct($postalInfo = null, $email = null, $voice = null, $fax = null, $password = null, $status = null) {
         parent::__construct($postalInfo, $email, $voice, $fax, $password, $status );
@@ -88,5 +89,16 @@ class euridEppContact extends eppContact {
 
     public function getContactExtCountryOfCitizenship() {
         return $this->countryOfCitizenship;
+    }
+
+    public function setNaturalPerson( $naturalPerson ) {
+        if( in_array( $naturalPerson, [true,false,null] ) )
+            $this->naturalPerson = $naturalPerson;
+        else
+            throw new \Exception('Natural person should be set to true, false or null');
+    }
+
+    public function getNaturalPerson() {
+        return $this->naturalPerson;
     }
 }

--- a/Protocols/EPP/eppExtensions/contact-ext-1.3/eppRequests/euridEppUpdateContactRequest.php
+++ b/Protocols/EPP/eppExtensions/contact-ext-1.3/eppRequests/euridEppUpdateContactRequest.php
@@ -1,0 +1,57 @@
+<?php
+namespace Metaregistrar\EPP;
+
+class euridEppUpdateContactRequest extends eppUpdateContactRequest {
+
+    /**
+     * euridEppUpdateContactRequest constructor.
+     * @throws eppException
+     */
+    function __construct($objectname, $addinfo = null, $removeinfo = null, $updateinfo = null, $namespacesinroot = true, $usecdata = true) {
+        parent::__construct($objectname, $addinfo, $removeinfo, $updateinfo, $namespacesinroot, $usecdata);
+        $this->addContactExtension($updateinfo);
+        $this->addSessionId();
+    }
+
+    /**
+     * @param object eppContact
+     */
+    public function addContactExtension(euridEppContact $updateinfo) {
+        $this->addExtension('xmlns:contact-ext', 'http://www.eurid.eu/xml/epp/contact-ext-1.3');
+        $update = $this->createElement('contact-ext:update');
+        $change = $this->createElement('contact-ext:chg');
+
+        if(!empty($updateinfo->getContactExtType())) {
+            $change->appendChild($this->createElement('contact-ext:type', $updateinfo->getContactExtType()));
+        }
+        if(!empty($updateinfo->getContactExtVat())) {
+            $change->appendChild($this->createElement('contact-ext:vat', $updateinfo->getContactExtVat()));
+        }
+        $org = false;
+        if (is_string($updateinfo->getPostalInfo(0)->getOrganisationName())) {
+            if (strlen($updateinfo->getPostalInfo(0)->getOrganisationName()) > 0) {
+                $org = true;
+            }
+        }
+
+        $change->appendChild($this->createElement('contact-ext:lang', $updateinfo->getContactExtLang()));
+
+        if( $updateinfo->getNaturalPerson() === null ) {
+            if ($org) {
+                $change->appendChild($this->createElement('contact-ext:naturalPerson', 'false'));
+            } else {
+                $change->appendChild($this->createElement('contact-ext:naturalPerson', 'true'));
+            }
+        } else {
+            $change->appendChild($this->createElement('contact-ext:naturalPerson', $updateinfo->getNaturalPerson() ? 'true' : 'false' ) );
+        }
+
+        if (is_string($updateinfo->getContactExtCountryOfCitizenship())) {
+            $change->appendChild($this->createElement('contact-ext:countryOfCitizenship', $updateinfo->getContactExtCountryOfCitizenship()));
+        }
+
+        $update->appendChild( $change );
+
+        $this->getExtension()->appendChild($update);
+    }
+}

--- a/Protocols/EPP/eppExtensions/contact-ext-1.3/includes.php
+++ b/Protocols/EPP/eppExtensions/contact-ext-1.3/includes.php
@@ -3,9 +3,11 @@ $this->addExtension('contact-ext', 'http://www.eurid.eu/xml/epp/contact-ext-1.3'
 
 include_once(dirname(__FILE__) . '/eppData/euridEppContact.php');
 include_once(dirname(__FILE__) . '/eppRequests/euridEppCreateContactRequest.php');
+include_once(dirname(__FILE__) . '/eppRequests/euridEppUpdateContactRequest.php');
 include_once(dirname(__FILE__) . '/eppResponses/euridEppInfoContactResponse.php');
-//include_once(dirname(__FILE__) . '/eppResponses/euridEppCreateContactResponse.php');
 
 $this->addCommandResponse('Metaregistrar\EPP\euridEppCreateContactRequest', 'Metaregistrar\EPP\eppCreateContactResponse');
+$this->addCommandResponse('Metaregistrar\EPP\euridEppUpdateContactRequest', 'Metaregistrar\EPP\eppUpdateContactResponse');
+
 
 


### PR DESCRIPTION
euridEppContact allows leaving the name and department tag empty. This results setting the natural person tag to the wrong value in curtain situaties. This update allows the natural person tag to be set "manually". Default situation is unchanged: the tag is set based on the name / department tags.

The new euridEppUpdateContactRequest supports this new functionality.