### PR TITLE
Fix PHP 8.1 deprecation warning

### DIFF
--- a/Protocols/EPP/eppData/eppContactPostalInfo.php
+++ b/Protocols/EPP/eppData/eppContactPostalInfo.php
@@ -131,7 +131,7 @@ class eppContactPostalInfo {
 
     /**
      * Gets the name
-     * @return string
+     * @return string|null
      */
     public function getName() {
         return $this->name;

--- a/Protocols/EPP/eppRequests/eppUpdateContactRequest.php
+++ b/Protocols/EPP/eppRequests/eppUpdateContactRequest.php
@@ -98,7 +98,7 @@ class eppUpdateContactRequest extends eppContactRequest {
             }
             $postalinfo->setAttribute('type', $postal->getType());
             // Mandatory field
-            if (strlen($postal->getName())>0) {
+            if (is_string($postal->getName()) && strlen($postal->getName()) > 0) {
                 $postalinfo->appendChild($this->createElement('contact:name', $postal->getName()));
             }
             // Optional field


### PR DESCRIPTION
> strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /php-epp-client/Protocols/EPP/eppRequests/eppUpdateContactRequest.php on line 101