### PR TITLE
SIDN - "organizationName" being set to null in parent constructor of sidnEppContactPostalInfo as It leads to get a null organisationName value

### DIFF
--- a/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/eppRequests/sidnEppContactPostalInfo.php
+++ b/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/eppRequests/sidnEppContactPostalInfo.php
@@ -30,7 +30,7 @@ class sidnEppContactPostalInfo extends eppContactPostalInfo {
             $this->legalForm = 'PERSOON';
         }
 
-        parent::__construct($name, $city, $countrycode, null, $street, $province, $zipcode, $type);
+        parent::__construct($name, $city, $countrycode, $organisationName, $street, $province, $zipcode, $type);
     }
 
     public function getLegalForm() {


### PR DESCRIPTION
In the constructor of the sidnEppContactPostalInfo class, the parameter $organisationName is set to null by default.

parent::__construct($name, $city, $countrycode, null, $street, $province, $zipcode, $type);

Because of this, when we try to get the organization of the contact Handles, we get a null value and we can't find whether the handle type is person or organization. In eppInfoContactResponse, we try to get the getContactCompanyname(), but because of the null value passing it in the constructor, always we are getting a null organisationName value.

I think it should be updated as with $organisationName instead of null.

parent::__construct($name, $city, $countrycode, $organisationName, $street, $province, $zipcode, $type);