### PR TITLE
support all RFC5731 status fields from EPP schema

### DIFF
--- a/Protocols/EPP/eppData/eppDomain.php
+++ b/Protocols/EPP/eppData/eppDomain.php
@@ -361,7 +361,7 @@ class eppDomain {
     
     /**
      *
-     * @param string $status
+     * @param string $status | eppStatus $status
      */
     public function addStatus($status) {
         $this->statuses[] = $status;
@@ -369,10 +369,32 @@ class eppDomain {
 
     /**
      *
+     * @param bool $fullobject
      * @return array
+     * 
      */
-    public function getStatuses() {
-        return $this->statuses;
+    public function getStatuses($fullobjects=false) {
+        $return_statuses=[];
+
+        if ($fullobjects) { // return full eppStatus Objects
+            foreach ($this->statuses as $status) {
+                if  ($status instanceof eppStatus) {
+                    $return_statuses[]=$status;
+                } else {
+                    $return_statuses[]=new eppStatus($status);
+                }
+            }
+        }  else {  // return just a list of statuses
+            foreach ($this->statuses as $status) {
+                if  ($status instanceof eppStatus) {
+                    $return_statuses[]=$status->getStatusname();
+                } else {
+                    $return_statuses[]=$status;
+                }
+            }
+        } 
+
+        return $return_statuses;
     }
 
 

--- a/Protocols/EPP/eppData/eppDomain.php
+++ b/Protocols/EPP/eppData/eppDomain.php
@@ -361,7 +361,7 @@ class eppDomain {
     
     /**
      *
-     * @param string $status | eppStatus $status
+     * @param string|eppStatus $status
      */
     public function addStatus($status) {
         $this->statuses[] = $status;

--- a/Protocols/EPP/eppData/eppStatus.php
+++ b/Protocols/EPP/eppData/eppStatus.php
@@ -31,27 +31,27 @@ class eppStatus {
 
     /**
      * Holds the status name
-     * @var <string>
+     * @var string 
      */
     private $statusname;
 
     /**
      * Holds the language from the status
-     * @var <string>
+     * @var string
      */
     private $language;
 
     /**
      * Holds the status message 
-    * @var <string>
+    * @var string
      */
     private $message;
 
     /**
      *
-     * @param <string> $statusname
-     * @param <string> $language
-     * @param <string> $message
+     * @param string $statusname
+     * @param ?string $language
+     * @param ?string $message
      */
     public function  __construct($statusname, $language = null, $message = null) {
         $this->setStatusname($statusname);

--- a/Protocols/EPP/eppData/eppStatus.php
+++ b/Protocols/EPP/eppData/eppStatus.php
@@ -1,0 +1,97 @@
+<?php
+namespace Metaregistrar\EPP;
+
+class eppStatus {
+    #
+    # These status values cannot be set, only viewed
+    #
+    const STATUS_OK = 'ok';
+    const STATUS_SERVER_DELETE_PROHIBITED = 'serverDeleteProhibited';
+    const STATUS_SERVER_UPDATE_PROHIBITED = 'serverUpdateProhibited';
+    const STATUS_SERVER_RENEW_PROHIBITED = 'serverRenewProhibited';
+    const STATUS_SERVER_TRANSFER_PROHIBITED = 'serverTransferProhibited';
+    const STATUS_SERVER_HOLD = 'serverHold';
+    const STATUS_INACTIVE = 'inactive';
+    const STATUS_PENDING_CREATE = 'pendingCreate';
+    const STATUS_PENDING_DELETE = 'pendingDelete';
+    const STATUS_PENDING_TRANSFER = 'pendingTransfer';
+    const STATUS_PENDING_UPDATE = 'pendingUpdate';
+    const STATUS_PENDING_RENEW = 'pendingRenew';
+
+    #
+    # These status values can be set
+    #
+    const STATUS_CLIENT_DELETE_PROHIBITED = 'clientDeleteProhibited';
+    const STATUS_CLIENT_UPDATE_PROHIBITED = 'clientUpdateProhibited';
+    const STATUS_CLIENT_RENEW_PROHIBITED = 'clientRenewProhibited';
+    const STATUS_CLIENT_TRANSFER_PROHIBITED = 'clientTransferProhibited';
+    const STATUS_CLIENT_HOLD = 'clientHold';
+
+
+
+    /**
+     * Holds the status name
+     * @var <string>
+     */
+    private $statusname;
+
+    /**
+     * Holds the language from the status
+     * @var <string>
+     */
+    private $language;
+
+    /**
+     * Holds the status message 
+    * @var <string>
+     */
+    private $message;
+
+    /**
+     *
+     * @param <string> $statusname
+     * @param <string> $language
+     * @param <string> $message
+     */
+    public function  __construct($statusname, $language = null, $message = null) {
+        $this->setStatusname($statusname);
+        if ($language) {
+            $this->setLanguage($language);
+        }
+        if ($message) {
+            $this->setMessage($message);
+        }
+    }
+
+    // getters
+    public function getStatusname() {
+        return $this->statusname;
+    }
+
+    public function getLanguage() {
+        return $this->language;
+    }
+
+    public function getMessage() {
+        return $this->message;
+    }
+
+
+    // setters
+    public function setStatusname($statusname) {
+        if (strlen($statusname) > 0) {
+            $this->statusname = $statusname;
+        } else {
+            throw new eppException("Statusname cannot be empty on eppStatus object");
+        }
+    }
+
+    public function setLanguage($language) {
+        $this->language = $language;
+    }
+
+    public function setMessage($message) {
+        $this->message = $message;
+    }
+
+}

--- a/Protocols/EPP/eppRequests/eppUpdateDomainRequest.php
+++ b/Protocols/EPP/eppRequests/eppUpdateDomainRequest.php
@@ -114,7 +114,7 @@ class eppUpdateDomainRequest extends eppDomainRequest {
     /**
      *
      * @param \domElement $element
-     * @param string $status | eppStatus $status
+     * @param string|eppStatus $status
      */
     protected function addDomainStatus($element, $status) {
         $stat = $this->createElement('domain:status');

--- a/Protocols/EPP/eppRequests/eppUpdateDomainRequest.php
+++ b/Protocols/EPP/eppRequests/eppUpdateDomainRequest.php
@@ -89,7 +89,7 @@ class eppUpdateDomainRequest extends eppDomainRequest {
                 $this->addDomainContact($element, $contact->getContactHandle(), $contact->getContactType());
             }
         }
-        $statuses = $domain->getStatuses();
+        $statuses = $domain->getStatuses(true);
         if (is_array($statuses)) {
             foreach ($statuses as $status) {
                 $this->addDomainStatus($element, $status);
@@ -114,11 +114,21 @@ class eppUpdateDomainRequest extends eppDomainRequest {
     /**
      *
      * @param \domElement $element
-     * @param string $status
+     * @param string $status | eppStatus $status
      */
     protected function addDomainStatus($element, $status) {
         $stat = $this->createElement('domain:status');
-        $stat->setAttribute('s', $status);
+
+        if ($status instanceof eppStatus) {
+            $stat = $this->createElement('domain:status',$status->getMessage());
+            $stat->setAttribute('s', $status->getStatusname());
+            if (!is_null($status->getLanguage())) {
+                $stat->setAttribute('lang', $status->getLanguage());
+            }
+
+        } else {
+            $stat->setAttribute('s', $status);
+        }
         $element->appendChild($stat);
     }
 

--- a/Protocols/EPP/eppResponses/eppInfoDomainResponse.php
+++ b/Protocols/EPP/eppResponses/eppInfoDomainResponse.php
@@ -49,9 +49,12 @@ class eppInfoDomainResponse extends eppInfoResponse {
     public function getDomainStatuses() {
         $statuses = null;
         $xpath = $this->xPath();
-        $result = $xpath->query('/epp:epp/epp:response/epp:resData/domain:infData/domain:status/@s');
+    //    $result = $xpath->query('/epp:epp/epp:response/epp:resData/domain:infData/domain:status/@s');
+        $result = $xpath->query('/epp:epp/epp:response/epp:resData/domain:infData/domain:status');
         foreach ($result as $status) {
-            $statuses[] = $status->nodeValue;
+            $statuses[] = new eppStatus($status->getAttribute('s'),
+                                        $status->getAttribute('lang'),
+                                         $status->nodeValue);
         }
         return $statuses;
     }


### PR DESCRIPTION
This PR adds support for all status fields (name, language and message) from RFC5731 :

```
   <!--
   Status is a combination of attributes and an optional
   human-readable message that may be expressed in languages other
   than English.
   -->
   <complexType name="statusType">
    <simpleContent>
      <extension base="normalizedString">
        <attribute name="s" type="domain:statusValueType"
         use="required"/>
        <attribute name="lang" type="language"
         default="en"/>
      </extension>
    </simpleContent>
   </complexType>
```

To set a status with a message, create a `eppStatus` object:

` $domain->addStatus(new eppStatus(eppDomain::STATUS_CLIENT_HOLD,'en','Payment overdue.'));`

setting the status as string still works to not break any running implementations:

`$domain->addStatus(eppDomain::STATUS_CLIENT_HOLD);`

To receive the status objects on a domain set the parameter `$fullobjects=true` on the `getStatuses`-method. 

```
   foreach ($d->getStatuses(true) as $status) {
            echo "  ".$status->getStatusname()." " .$status->getMessage()."\n";
        }
```

if not set or set to false, the statuses are returned as an array of strings like in the current implementation.
