### PR TITLE
Add support for SIDN scheduledDelete

### DIFF
--- a/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/eppRequests/sidnEppUpdateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/eppRequests/sidnEppUpdateDomainRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Metaregistrar\EPP;
+
+class sidnEppUpdateDomainRequest extends eppUpdateDomainRequest
+{
+    function __construct($objectname, $addinfo = null, $removeinfo = null, $updateinfo = null, $forcehostattr=false, $namespacesinroot = true, $usecdata = true, $scheduledDeleteOperation = null, $scheduledDeleteDate = null) {
+        parent::__construct($objectname, $addinfo, $removeinfo, $updateinfo, $forcehostattr, $namespacesinroot, $usecdata);
+
+        if ($scheduledDeleteOperation) {
+            $this->addScheduledDelete($scheduledDeleteOperation, $scheduledDeleteDate);
+        }
+
+        parent::addSessionId();
+    }
+
+    private function addScheduledDelete($scheduledDeleteOperation = null, $scheduledDeleteDate = null) {
+        $sidnExt = $this->createElement('scheduledDelete:update');
+        $operationElement = $this->createElement('scheduledDelete:operation', $scheduledDeleteOperation);
+        $sidnExt->appendChild($operationElement);
+
+        if ($scheduledDeleteDate) {
+            $dateElement = $this->createElement('scheduledDelete:date', $scheduledDeleteDate);
+            $sidnExt->appendChild($dateElement);
+        }
+
+        $this->getExtension()->appendChild($sidnExt);
+    }
+}

--- a/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/eppRequests/sidnEppUpdateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/eppRequests/sidnEppUpdateDomainRequest.php
@@ -5,6 +5,10 @@ namespace Metaregistrar\EPP;
 class sidnEppUpdateDomainRequest extends eppUpdateDomainRequest
 {
     function __construct($objectname, $addinfo = null, $removeinfo = null, $updateinfo = null, $forcehostattr=false, $namespacesinroot = true, $usecdata = true, $scheduledDeleteOperation = null, $scheduledDeleteDate = null) {
+        if (!$updateinfo) {
+            $updateinfo = $objectname;
+        }
+
         parent::__construct($objectname, $addinfo, $removeinfo, $updateinfo, $forcehostattr, $namespacesinroot, $usecdata);
 
         if ($scheduledDeleteOperation) {

--- a/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/includes.php
+++ b/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/includes.php
@@ -1,5 +1,6 @@
 <?php
 $this->addExtension('sidn-ext-epp', 'http://rxsd.domain-registry.nl/sidn-ext-epp-1.0');
+$this->addExtension('scheduledDelete', 'http://rxsd.domain-registry.nl/sidn-ext-epp-scheduled-delete-1.0');
 
 include_once(dirname(__FILE__) . '/eppResponses/sidnEppResponse.php');
 

--- a/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/includes.php
+++ b/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/includes.php
@@ -29,7 +29,7 @@ $this->addCommandResponse('Metaregistrar\EPP\sidnEppInfoDomainRequest', 'Metareg
 include_once(dirname(__FILE__) . '/eppRequests/sidnEppCancelDeleteRequest.php');
 $this->addCommandResponse('Metaregistrar\EPP\sidnEppCancelDeleteRequest', 'Metaregistrar\EPP\eppResponse');
 
-include_once(dirname(__FILE__) . '/eppRequests/sidnEppUpdateDomainRequest.php.php');
+include_once(dirname(__FILE__) . '/eppRequests/sidnEppUpdateDomainRequest.php');
 $this->addCommandResponse('Metaregistrar\EPP\sidnEppUpdateDomainRequest', 'Metaregistrar\EPP\eppResponse');
 
 include_once(dirname(__FILE__) . '/eppExceptions/sidnEppException.php');

--- a/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/includes.php
+++ b/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/includes.php
@@ -29,5 +29,8 @@ $this->addCommandResponse('Metaregistrar\EPP\sidnEppInfoDomainRequest', 'Metareg
 include_once(dirname(__FILE__) . '/eppRequests/sidnEppCancelDeleteRequest.php');
 $this->addCommandResponse('Metaregistrar\EPP\sidnEppCancelDeleteRequest', 'Metaregistrar\EPP\eppResponse');
 
+include_once(dirname(__FILE__) . '/eppRequests/sidnEppUpdateDomainRequest.php.php');
+$this->addCommandResponse('Metaregistrar\EPP\sidnEppUpdateDomainRequest', 'Metaregistrar\EPP\eppResponse');
+
 include_once(dirname(__FILE__) . '/eppExceptions/sidnEppException.php');
 $this->addException('Metaregistrar\EPP\sidnEppException');


### PR DESCRIPTION
This PR adds support for setting a scheduled delete date for a .nl domain. 

https://rxsd.domain-registry.nl/sidn-ext-epp-scheduled-delete-1.0