### PR TITLE
Add SK-NIC Support (.sk, .org.sk).

### DIFF
--- a/Protocols/EPP/eppConnection.php
+++ b/Protocols/EPP/eppConnection.php
@@ -131,6 +131,12 @@ class eppConnection {
     protected $local_cert_path = null;
 
     /**
+     * Path to private key file
+     * @var string
+     */
+    protected $local_pk_path = null;
+
+    /**
      * Password of certificate file
      * @var string
      */
@@ -301,18 +307,21 @@ class eppConnection {
      * @param string $certificatepath
      * @param string | null $certificatepassword
      * @param bool $selfsigned
+     * @param string | null $certificatekeypath
      *
      */
-    public function enableCertification($certificatepath, $certificatepassword, $selfsigned = false) {
+    public function enableCertification($certificatepath, $certificatepassword, $selfsigned = false, $certificatekeypath = null) {
         $this->local_cert_path = $certificatepath;
         $this->local_cert_pwd = $certificatepassword;
         $this->allow_self_signed = $selfsigned;
+        $this->local_pk_path = $certificatekeypath;
     }
 
     public function disableCertification() {
         $this->local_cert_path = null;
         $this->local_cert_pwd = null;
         $this->allow_self_signed = null;
+        $this->local_pk_path = null;
     }
 
 
@@ -352,6 +361,9 @@ class eppConnection {
             stream_context_set_option($context, 'ssl', 'verify_peer_name', $this->verify_peer_name);
             if ($this->local_cert_path) {
                 stream_context_set_option($context, 'ssl', 'local_cert', $this->local_cert_path);
+                if (isset($this->local_pk_path) && (strlen($this->local_pk_path)>0)) {
+                    stream_context_set_option($context, 'ssl', 'local_pk', $this->local_pk_path);
+                }
                 if (isset($this->local_cert_pwd) && (strlen($this->local_cert_pwd)>0)) {
                     stream_context_set_option($context, 'ssl', 'passphrase', $this->local_cert_pwd);
                 }
@@ -379,10 +391,10 @@ class eppConnection {
                 $this->read();
             }
             return $this->connected;
-        } else {
-            $this->writeLog("Connection could not be opened: $errno $errstr","ERROR");
-            return false;
         }
+
+        $this->writeLog("Connection could not be opened: $errno $errstr","ERROR");
+        return false;
 
     }
 
@@ -1148,14 +1160,6 @@ class eppConnection {
                 $this->enableLogging();
             }
         }
-
-        if (array_key_exists('certificatefile',$result) && array_key_exists('certificatepassword',$result)) {
-            // Enter the path to your certificate and the password here
-            $this->enableCertification($result['certificatefile'], $result['certificatepassword']);
-        } elseif (array_key_exists('certificatefile',$result)) {
-            // Enter the path to your certificate without password
-            $this->enableCertification($result['certificatefile'], null);
-        }
         if (array_key_exists('verifypeer',$result)) {
             if (($result['verifypeer']=='true') || ($result['verifypeer']=='yes') || ($result['verifypeer']=='1')) {
                 $this->verify_peer = true;
@@ -1176,6 +1180,14 @@ class eppConnection {
             } else {
                 $this->allow_self_signed = false;
             }
+        }
+        if (array_key_exists('certificatefile',$result)) {
+            $this->enableCertification(
+                $result['certificatefile'],
+                array_key_exists('certificatepassword',$result) ? $result['certificatepassword'] : null,
+                $this->allow_self_signed,
+                array_key_exists('certificatekey',$result) ? $result['certificatekey'] : null
+            );
         }
 
         $this->settingsloaded = true;

--- a/Protocols/EPP/eppException.php
+++ b/Protocols/EPP/eppException.php
@@ -29,7 +29,7 @@ class eppException extends \Exception {
      * @param string $command
      * @param \Metaregistrar\EPP\eppResponse|null $response
      */
-    public function __construct($message = "", $code = 0, \Exception $previous = null, $reason = null, $command = null, $response = null) {
+    public function __construct($message = "", $code = 0, $previous = null, $reason = null, $command = null, $response = null) {
         $this->reason = $reason;
         $trace = $this->getTrace();
         $this->class = null;

--- a/Protocols/EPP/eppExtensions/auxcontact-0.1/eppRequests/AuxContactCreateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/auxcontact-0.1/eppRequests/AuxContactCreateDomainRequest.php
@@ -1,0 +1,89 @@
+<?php
+namespace Metaregistrar\EPP;
+
+/**
+ * Class AuxContactCreateDomainRequest
+ * @package Metaregistrar\EPP
+ *
+ * <extension>
+ *  <auxcontact:create xmlns:auxcontact="urn:ietf:params:xml:ns:auxcontact-0.1">
+ *      <auxcontact:contact type="abuse">sh8013</auxcontact:contact>
+ *      <auxcontact:contact type="dns-operator">ClientZ</auxcontact:contact>
+ *  </auxcontact:create>
+ * </extension>
+ */
+class AuxContactCreateDomainRequest extends eppCreateDomainRequest
+{
+    /**
+     * @var array Auxiliary contacts to include in domain creation
+     */
+    private $auxContacts = [];
+
+    /**
+     * AuxContactCreateDomainRequest constructor
+     *
+     * @param eppDomain $createinfo Domain object to create
+     * @param boolean $forcehostattr Force host attributes
+     * @param boolean $namespacesinroot Namespaces in root
+     * @param boolean $usecdata Use CDATA
+     * @param array $auxContacts Auxiliary contacts to add [['type' => 'type', 'id' => 'id'], ...]
+     */
+    function __construct($createinfo, $forcehostattr = false, $namespacesinroot = true, $usecdata = true, $auxContacts = [])
+    {
+        parent::__construct($createinfo, $forcehostattr, $namespacesinroot, $usecdata);
+
+        // Store contacts
+        $this->auxContacts = $auxContacts;
+
+        // Add the extension to the request
+        $this->addAuxContactExtension();
+
+        // Add session ID
+        $this->addSessionId();
+    }
+
+    /**
+     * Add auxiliary contact to the request
+     *
+     * @param string $type Contact type (e.g., 'abuse', 'dns-operator')
+     * @param string $contactId Contact ID
+     * @return $this
+     */
+    public function addAuxContact($type, $contactId)
+    {
+        $this->auxContacts[] = [
+            'type' => $type,
+            'id' => $contactId
+        ];
+
+        // Refresh extension
+        $this->addAuxContactExtension();
+
+        return $this;
+    }
+
+    /**
+     * Add the auxiliary contact extension to the request
+     */
+    private function addAuxContactExtension()
+    {
+        // Skip if no contacts to add
+        if (empty($this->auxContacts)) {
+            return;
+        }
+
+        // Create the auxcontact:create an element
+        $createElement = $this->createElement('auxcontact:create');
+        $this->setNamespace('auxcontact', 'urn:ietf:params:xml:ns:auxcontact-0.1', $createElement);
+
+        // Add contacts
+        foreach ($this->auxContacts as $contact) {
+            $contactElement = $this->createElement('auxcontact:contact', htmlspecialchars($contact['id']));
+            $contactElement->setAttribute('type', htmlspecialchars($contact['type']));
+            $createElement->appendChild($contactElement);
+        }
+
+        // Add to the extension element
+        $this->getExtension()->appendChild($createElement);
+    }
+}

--- a/Protocols/EPP/eppExtensions/auxcontact-0.1/eppRequests/AuxContactUpdateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/auxcontact-0.1/eppRequests/AuxContactUpdateDomainRequest.php
@@ -1,0 +1,142 @@
+<?php
+namespace Metaregistrar\EPP;
+
+/**
+ * Class AuxContactUpdateDomainRequest
+ * @package Metaregistrar\EPP
+ *
+ * <extension>
+ *  <auxcontact:update xmlns:auxcontact="urn:ietf:params:xml:ns:auxcontact-0.1">
+ *      <auxcontact:rem>
+ *          <auxcontact:contact type="dns-operator">ClientZ</auxcontact:contact>
+ *      </auxcontact:rem>
+ *      <auxcontact:add>
+ *          <auxcontact:contact type="dns-operator">ClientXYZ</auxcontact:contact>
+ *      </auxcontact:add>
+ *  </auxcontact:update>
+ * </extension>
+ */
+class AuxContactUpdateDomainRequest extends eppUpdateDomainRequest
+{
+    /**
+     * @var array Auxiliary contacts to add
+     */
+    private $addAuxContacts = [];
+
+    /**
+     * @var array Auxiliary contacts to remove
+     */
+    private $removeAuxContacts = [];
+
+    /**
+     * AuxContactUpdateDomainRequest constructor
+     *
+     * @param eppDomain $objectname Domain object to update
+     * @param eppDomain $addinfo Elements to add
+     * @param eppDomain $removeinfo Elements to remove
+     * @param eppDomain $updateinfo Elements to update
+     * @param boolean $forcehostattr Force host attributes
+     * @param boolean $namespacesinroot Namespaces in root
+     * @param boolean $usecdata Use CDATA
+     * @param array $addAuxContacts Auxiliary contacts to add [['type' => 'type', 'id' => 'id'], ...]
+     * @param array $removeAuxContacts Auxiliary contacts to remove [['type' => 'type', 'id' => 'id'], ...]
+     */
+    function __construct($objectname, $addinfo = null, $removeinfo = null, $updateinfo = null, $forcehostattr = false, $namespacesinroot = true, $usecdata = true, $addAuxContacts = [], $removeAuxContacts = [])
+    {
+        parent::__construct($objectname, $addinfo, $removeinfo, $updateinfo, $forcehostattr, $namespacesinroot, $usecdata);
+
+        // Store contacts to add and remove
+        $this->addAuxContacts = $addAuxContacts;
+        $this->removeAuxContacts = $removeAuxContacts;
+
+        // Add the extension to the request
+        $this->addAuxContactExtension();
+
+        // Add session ID
+        $this->addSessionId();
+    }
+
+    /**
+     * Add auxiliary contact to add list
+     *
+     * @param string $type Contact type (e.g., 'abuse', 'dns-operator')
+     * @param string $contactId Contact ID
+     * @return $this
+     */
+    public function addAuxContact($type, $contactId)
+    {
+        $this->addAuxContacts[] = [
+            'type' => $type,
+            'id' => $contactId
+        ];
+
+        // Refresh extension
+        $this->addAuxContactExtension();
+
+        return $this;
+    }
+
+    /**
+     * Add auxiliary contact to remove list
+     *
+     * @param string $type Contact type (e.g., 'abuse', 'dns-operator')
+     * @param string $contactId Contact ID
+     * @return $this
+     */
+    public function removeAuxContact($type, $contactId)
+    {
+        $this->removeAuxContacts[] = [
+            'type' => $type,
+            'id' => $contactId
+        ];
+
+        // Refresh extension
+        $this->addAuxContactExtension();
+
+        return $this;
+    }
+
+    /**
+     * Add the auxiliary contact extension to the request
+     */
+    private function addAuxContactExtension()
+    {
+        // Skip if no contacts to add or remove
+        if (empty($this->addAuxContacts) && empty($this->removeAuxContacts)) {
+            return;
+        }
+
+        // Create the auxcontact:update element
+        $updateElement = $this->createElement('auxcontact:update');
+        $this->setNamespace('auxcontact', 'urn:ietf:params:xml:ns:auxcontact-0.1', $updateElement);
+
+        // Add contacts to remove
+        if (!empty($this->removeAuxContacts)) {
+            $remElement = $this->createElement('auxcontact:rem');
+
+            foreach ($this->removeAuxContacts as $contact) {
+                $contactElement = $this->createElement('auxcontact:contact', htmlspecialchars($contact['id']));
+                $contactElement->setAttribute('type', htmlspecialchars($contact['type']));
+                $remElement->appendChild($contactElement);
+            }
+
+            $updateElement->appendChild($remElement);
+        }
+
+        // Add contacts to add
+        if (!empty($this->addAuxContacts)) {
+            $addElement = $this->createElement('auxcontact:add');
+
+            foreach ($this->addAuxContacts as $contact) {
+                $contactElement = $this->createElement('auxcontact:contact', htmlspecialchars($contact['id']));
+                $contactElement->setAttribute('type', htmlspecialchars($contact['type']));
+                $addElement->appendChild($contactElement);
+            }
+
+            $updateElement->appendChild($addElement);
+        }
+
+        // Add to the extension element
+        $this->getExtension()->appendChild($updateElement);
+    }
+}

--- a/Protocols/EPP/eppExtensions/auxcontact-0.1/eppResponses/AuxContactInfoDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/auxcontact-0.1/eppResponses/AuxContactInfoDomainResponse.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Metaregistrar\EPP;
+
+/**
+ * Class AuxContactInfoDomainResponse
+ * @package Metaregistrar\EPP
+ *
+ *
+ * <extension>
+ *  <auxcontact:infData xmlns:auxcontact="urn:ietf:params:xml:ns:auxcontact-0.1">
+ *      <auxcontact:contact type="abuse">sh8013</auxcontact:contact>
+ *      <auxcontact:contact type="dns-operator">ClientZ</auxcontact:contact>
+ *  </auxcontact:infData>
+ * </extension>
+ */
+class AuxContactInfoDomainResponse extends eppInfoDomainResponse
+{
+    /**
+     * @var array Auxiliary contacts
+     */
+    private $auxContacts = [];
+
+    /**
+     * Get the auxiliary contacts
+     *
+     * @return array
+     */
+    public function getAuxContacts()
+    {
+        if (empty($this->auxContacts)) {
+            $this->extractAuxContacts();
+        }
+        return $this->auxContacts;
+    }
+
+    /**
+     * Extract the auxiliary contacts from the response
+     */
+    private function extractAuxContacts()
+    {
+        $xpath = $this->xPath();
+
+        // Register the namespace
+        $xpath->registerNamespace('auxcontact', 'urn:ietf:params:xml:ns:auxcontact-0.1');
+
+        // Extract auxiliary contacts
+        $contacts = $xpath->query('/epp:epp/epp:response/epp:extension/auxcontact:infData/auxcontact:contact');
+
+        if ($contacts->length > 0) {
+            foreach ($contacts as $contact) {
+                $type = $contact->getAttribute('type');
+                $id = $contact->nodeValue;
+
+                $this->auxContacts[] = [
+                    'type' => $type,
+                    'id' => $id
+                ];
+            }
+        }
+    }
+
+    /**
+     * Get auxiliary contacts of a specific type
+     *
+     * @param string $type
+     * @return array
+     */
+    public function getAuxContactsByType($type)
+    {
+        if (empty($this->auxContacts)) {
+            $this->extractAuxContacts();
+        }
+
+        $result = [];
+
+        foreach ($this->auxContacts as $contact) {
+            if ($contact['type'] === $type) {
+                $result[] = $contact['id'];
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the abuse contact ID if it exists
+     *
+     * @return string|null
+     */
+    public function getAbuseContact()
+    {
+        $contacts = $this->getAuxContactsByType('abuse');
+        return count($contacts) > 0 ? $contacts[0] : null;
+    }
+
+    /**
+     * Get the DNS operator contact ID if it exists
+     *
+     * @return string|null
+     */
+    public function getDnsOperatorContact()
+    {
+        $contacts = $this->getAuxContactsByType('dns-operator');
+        return count($contacts) > 0 ? $contacts[0] : null;
+    }
+}

--- a/Protocols/EPP/eppExtensions/auxcontact-0.1/includes.php
+++ b/Protocols/EPP/eppExtensions/auxcontact-0.1/includes.php
@@ -1,0 +1,10 @@
+<?php
+$this->addExtension('auxcontact', 'urn:ietf:params:xml:ns:auxcontact-0.1');
+
+include_once(__DIR__ . '/eppResponses/AuxContactInfoDomainResponse.php');
+$this->addCommandResponse('Metaregistrar\EPP\eppInfoDomainRequest', 'Metaregistrar\EPP\AuxContactInfoDomainResponse');
+
+include_once(__DIR__ . '/eppRequests/AuxContactCreateDomainRequest.php');
+include_once(__DIR__ . '/eppRequests/AuxContactUpdateDomainRequest.php');
+$this->addCommandResponse('Metaregistrar\EPP\AuxContactCreateDomainRequest', 'Metaregistrar\EPP\eppCreateDomainResponse');
+$this->addCommandResponse('Metaregistrar\EPP\AuxContactUpdateDomainRequest', 'Metaregistrar\EPP\eppUpdateDomainResponse');

--- a/Protocols/EPP/eppExtensions/sk-contact-ident-0.2/eppData/sknicEppContactPostalInfo.php
+++ b/Protocols/EPP/eppExtensions/sk-contact-ident-0.2/eppData/sknicEppContactPostalInfo.php
@@ -1,0 +1,88 @@
+<?php
+namespace Metaregistrar\EPP;
+
+use DOMDocument;
+use DOMElement;
+use DOMException;
+
+class sknicEppContactPostalInfo extends eppContactPostalInfo
+{
+    private $legalForm;
+    private $corpIdent;
+    private $birthDate;
+
+    private $allowedLegalForms = [
+        'PERS',
+        'CORP',
+    ];
+
+    /**
+     * @throws eppException
+     */
+    public function __construct($name = null, $city = null, $countrycode = null, $organisationName = null, $street = null, $province = null, $zipcode = null, $type = eppContact::TYPE_AUTO, $legalForm = null, $corpIdentOrBirthDate = null) {
+
+        parent::__construct($name, $city, $countrycode, $organisationName, $street, $province, $zipcode, $type);
+
+        if (!in_array($legalForm, $this->allowedLegalForms, true)) {
+            throw new eppException('Invalid legal form. Allowed values are: ' . implode(', ', $this->allowedLegalForms));
+        }
+
+        $this->setLegalForm($legalForm);
+        if ($legalForm === 'PERS') {
+            $this->setBirthDate($corpIdentOrBirthDate);
+        } else {
+            $this->setCorpIdent($corpIdentOrBirthDate);
+        }
+    }
+
+    public function setLegalForm(string $legalForm): self
+    {
+        $this->legalForm = $legalForm;
+        return $this;
+    }
+
+    public function setCorpIdent(string $corpIdent): self
+    {
+        $this->corpIdent = htmlspecialchars($corpIdent, ENT_COMPAT, "UTF-8");
+        return $this;
+    }
+
+    public function setBirthDate(string $birthDate): self
+    {
+        $this->birthDate = $birthDate;
+        return $this;
+    }
+
+    /**
+     * @throws DOMException
+     */
+    public function generateXML(DOMDocument $xml): DOMElement
+    {
+        $extension = $xml->createElement('extension');
+        $create = $xml->createElement('skContactIdent:create');
+        $create->setAttribute('xmlns:skContactIdent', 'http://www.sk-nic.sk/xml/epp/sk-contact-ident-0.2');
+
+        // Legal form (PERS or CORP)
+        $legalFormElement = $xml->createElement('skContactIdent:legalForm', $this->legalForm);
+        $create->appendChild($legalFormElement);
+
+        // If CORP, add identification number
+        if ($this->legalForm === 'CORP' && !empty($this->corpIdent)) {
+            $identValue = $xml->createElement('skContactIdent:identValue');
+            $corpIdentElement = $xml->createElement('skContactIdent:corpIdent', $this->corpIdent);
+            $identValue->appendChild($corpIdentElement);
+            $create->appendChild($identValue);
+        }
+
+        // If PERS, optionally add birthdate
+        if ($this->legalForm === 'PERS' && !empty($this->birthDate)) {
+            $identValue = $xml->createElement('skContactIdent:identValue');
+            $birthDateElement = $xml->createElement('skContactIdent:persIdent', $this->birthDate);
+            $identValue->appendChild($birthDateElement);
+            $create->appendChild($identValue);
+        }
+
+        $extension->appendChild($create);
+        return $extension;
+    }
+}

--- a/Protocols/EPP/eppExtensions/sk-contact-ident-0.2/eppRequests/sknicEppCreateContactRequest.php
+++ b/Protocols/EPP/eppExtensions/sk-contact-ident-0.2/eppRequests/sknicEppCreateContactRequest.php
@@ -1,0 +1,52 @@
+<?php
+namespace Metaregistrar\EPP;
+/*
+ * Extension example: Corporation
+<extension>
+      <skContactIdent:create
+        xmlns:skContactIdent="http://www.sk-nic.sk/xml/epp/sk-contact-ident-0.2">
+      <skContactIdent:legalForm>CORP</skContactIdent:legalForm>
+      <skContactIdent:identValue>
+        <skContactIdent:corpIdent>1234567890</skContactIdent:corpIdent>
+      </skContactIdent:identValue>
+      </skContactIdent:create>
+</extension>
+ * Extension example: Natural person
+<extension>
+      <skContactIdent:create
+        xmlns:skContactIdent="http://www.sk-nic.sk/xml/epp/sk-contact-ident-0.2">
+      <skContactIdent:legalForm>PERS</skContactIdent:legalForm>
+      </skContactIdent:create>
+</extension>
+*/
+
+class sknicEppCreateContactRequest extends eppCreateContactRequest {
+    function __construct(eppContact $createinfo, $namespacesinroot = true, $usecdata = true) {
+        parent::__construct($createinfo, $namespacesinroot, $usecdata);
+
+        $this->addContactExtension($createinfo);
+
+        // Add session ID
+        $this->addSessionId();
+    }
+
+    /**
+     * @param eppContact $createinfo
+     * @throws eppException
+     */
+    public function addContactExtension(eppContact $createinfo) {
+        // Get the postal info to extract the SK-NIC specific data
+        $postalInfo = $createinfo->getPostalInfo(0);
+
+        // Check if it's the sknicEppContactPostalInfo class
+        if ($postalInfo instanceof sknicEppContactPostalInfo) {
+            // Use the generateXML method from the postal info class
+            $existingElement = $this->getElementsByTagName('command')->item(0);
+            $doc = $existingElement->ownerDocument;
+            $extensionElement = $postalInfo->generateXML($doc);
+            $this->getExtension()->appendChild($extensionElement->firstChild);
+        } else {
+            throw new eppException("Postal info must be of type sknicEppContactPostalInfo");
+        }
+    }
+}

--- a/Protocols/EPP/eppExtensions/sk-contact-ident-0.2/eppRequests/sknicEppUpdateContactRequest.php
+++ b/Protocols/EPP/eppExtensions/sk-contact-ident-0.2/eppRequests/sknicEppUpdateContactRequest.php
@@ -1,0 +1,52 @@
+<?php
+namespace Metaregistrar\EPP;
+/*
+ * Extension example: Corporation
+<extension>
+      <skContactIdent:create
+        xmlns:skContactIdent="http://www.sk-nic.sk/xml/epp/sk-contact-ident-0.2">
+      <skContactIdent:legalForm>CORP</skContactIdent:legalForm>
+      <skContactIdent:identValue>
+        <skContactIdent:corpIdent>1234567890</skContactIdent:corpIdent>
+      </skContactIdent:identValue>
+      </skContactIdent:create>
+</extension>
+ * Extension example: Natural person
+<extension>
+      <skContactIdent:create
+        xmlns:skContactIdent="http://www.sk-nic.sk/xml/epp/sk-contact-ident-0.2">
+      <skContactIdent:legalForm>PERS</skContactIdent:legalForm>
+      </skContactIdent:create>
+</extension>
+*/
+
+class sknicEppUpdateContactRequest extends eppUpdateContactRequest {
+    function __construct($objectname, $addinfo = null, $removeinfo = null, $updateinfo = null, $namespacesinroot = true, $usecdata = true) {
+        parent::__construct($objectname, $addinfo, $removeinfo, $updateinfo, $namespacesinroot, $usecdata);
+
+        $this->addContactExtension($updateinfo);
+
+        // Add session ID
+        $this->addSessionId();
+    }
+
+    /**
+     * @param eppContact $updateInfo
+     * @throws eppException
+     */
+    public function addContactExtension(eppContact $updateInfo) {
+        // Get the postal info to extract the SK-NIC specific data
+        $postalInfo = $updateInfo->getPostalInfo(0);
+
+        // Check if it's the sknicEppContactPostalInfo class
+        if ($postalInfo instanceof sknicEppContactPostalInfo) {
+            // Use the generateXML method from the postal info class
+            $existingElement = $this->getElementsByTagName('command')->item(0);
+            $doc = $existingElement->ownerDocument;
+            $extensionElement = $postalInfo->generateXML($doc);
+            $this->getExtension()->appendChild($extensionElement->firstChild);
+        } else {
+            throw new eppException("Postal info must be of type sknicEppContactPostalInfo");
+        }
+    }
+}

--- a/Protocols/EPP/eppExtensions/sk-contact-ident-0.2/includes.php
+++ b/Protocols/EPP/eppExtensions/sk-contact-ident-0.2/includes.php
@@ -1,0 +1,9 @@
+<?php
+$this->addExtension('sk-contact-ident', 'http://www.sk-nic.sk/xml/epp/sk-contact-ident-0.2');
+
+include_once(__DIR__ . '/eppData/sknicEppContactPostalInfo.php');
+include_once(__DIR__ . '/eppRequests/sknicEppCreateContactRequest.php');
+include_once(__DIR__ . '/eppRequests/sknicEppUpdateContactRequest.php');
+
+$this->addCommandResponse('Metaregistrar\EPP\sknicEppCreateContactRequest', 'Metaregistrar\EPP\eppCreateContactResponse');
+$this->addCommandResponse('Metaregistrar\EPP\sknicEppUpdateContactRequest', 'Metaregistrar\EPP\eppUpdateContactResponse');

--- a/Protocols/EPP/eppResponses/eppResponse.php
+++ b/Protocols/EPP/eppResponses/eppResponse.php
@@ -110,7 +110,7 @@ class eppResponse extends \DOMDocument {
     }
 
     #[\ReturnTypeWillChange]
-    public function saveXML(\DOMNode $node = NULL, $options = NULL) {
+    public function saveXML($node = null, $options = 0) {
         return str_replace("\t", '  ', parent::saveXML($node, LIBXML_NOEMPTYTAG));
     }
 
@@ -376,7 +376,7 @@ class eppResponse extends \DOMDocument {
      */
     public function xPath() {
         $xpath = new \DOMXpath($this);
-        $this->defaultnamespace = $this->documentElement->lookupNamespaceUri(NULL);
+        $this->defaultnamespace = $this->documentElement->lookupNamespaceUri(null);
         $xpath->registerNamespace('epp', $this->defaultnamespace);
         if (is_array($this->xpathuri)) {
             foreach ($this->xpathuri as $uri => $namespace) {

--- a/Protocols/TMCH/tmchData/tmchClaimData.php
+++ b/Protocols/TMCH/tmchData/tmchClaimData.php
@@ -175,7 +175,7 @@ class tmchClaimData extends \DOMDocument {
 
     public function xPath() {
         $xpath = new \DOMXpath($this);
-        $this->publicnamespace = $this->documentElement->lookupNamespaceUri(NULL);
+        $this->publicnamespace = $this->documentElement->lookupNamespaceUri(null);
         $xpath->registerNamespace('tmNotice', $this->publicnamespace);
         return $xpath;
     }

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Currently supported registries:
 - Norid (.no)
 - Arnes (.si)
 - Nic.lv (.lv)
+- SK-NIC (.sk)
 
 
 All code changes are tested automatically with the phpunit tests in the Tests directory
@@ -92,6 +93,7 @@ How to use this repository
         password=xxxxxxxxx
         logging=true
         certificatefile=/home/xxxxxx/xxxxxxx.pem
+        certificatekey=/home/xxxxxx/xxxxxxx.key
         certificatepassword=xxxxxxx
         verifypeer=true/false
         verifypeername=true/false

--- a/Registries/sknicEppConnection/eppConnection.php
+++ b/Registries/sknicEppConnection/eppConnection.php
@@ -1,0 +1,28 @@
+<?php
+namespace Metaregistrar\EPP;
+
+/**
+ * Class sknicEppConnection
+ * @package Metaregistrar\EPP
+ *
+ * This class is used to connect to the SK-NIC EPP server.
+ * It extends the eppConnection class and sets the appropriate settings for SK-NIC.
+ */
+class sknicEppConnection extends eppConnection {
+    /**
+     * sknicEppConnection constructor.
+     * @param bool $logging
+     * @param null $settingsfile
+     */
+    public function __construct($logging = false, $settingsfile = null) {
+        parent::__construct($logging, $settingsfile);
+
+        parent::setLanguage('en'); // Allows only EN
+
+        parent::enableDnssec();
+        parent::enableRgp();
+
+        parent::useExtension('sk-contact-ident-0.2');
+        parent::useExtension('auxcontact-0.1');
+    }
+}

--- a/Registries/sknicEppConnection/sknic.php
+++ b/Registries/sknicEppConnection/sknic.php
@@ -595,38 +595,38 @@ try {
     if ($conn = sknicEppConnection::create('settings.ini', false)) {
         // Connect and login to the EPP server
         if ($conn->login()) {
-//            echo "Hellol\n";
-//            $hello = hello($conn);
-//            var_dump($hello);
+            echo "Hellol\n";
+            $hello = hello($conn);
+            var_dump($hello);
 
             echo "Checking poll\n";
             checkPoll($conn);
 
-//            echo "Checking " . count($domains) . " domain names\n";
-//            checkDomains($conn, $domains);
-//
-//            echo "Checking contact\n";
-//            checkContact($conn,'UBOM-0334');
-//
-//            echo "Checking hosts\n";
-//            checkHosts($conn,['ns1.unknow.sk','ns2.unknow.sk','ns3.unknow.sk']);
+            echo "Checking " . count($domains) . " domain names\n";
+            checkDomains($conn, $domains);
 
-//            echo "Creating hosts\n";
-//            $host_id1 = createHost($conn,'ns1.unknow.sk', ['1.2.3.4']);
-//            $host_id2 = createHost($conn,'ns2.unknow.sk', ['5.6.7.8']);
-//
-//            echo "Checking hosts after create\n";
-//            checkHosts($conn,['ns1.unknow.sk','ns2.unknow.sk','ns3.unknow.sk']);
-//
-//            echo "Get host info\n";
-//            getHostInfo($conn, 'ns1.unknow.sk');
+            echo "Checking contact\n";
+            checkContact($conn,'UBOM-0334');
 
-//            echo "Removing hosts\n";
-//            deleteHost($conn, 'ns1.unknow.sk');
-//            deleteHost($conn, 'ns2.unknow.sk');
-//
-//            echo "Checking hosts after delete\n";
-//            checkHosts($conn,['ns1.unknow.sk','ns2.unknow.sk','ns3.unknow.sk']);
+            echo "Checking hosts\n";
+            checkHosts($conn,['ns1.unknow.sk','ns2.unknow.sk','ns3.unknow.sk']);
+
+            echo "Creating hosts\n";
+            $host_id1 = createHost($conn,'ns1.unknow.sk', ['1.2.3.4']);
+            $host_id2 = createHost($conn,'ns2.unknow.sk', ['5.6.7.8']);
+
+            echo "Checking hosts after create\n";
+            checkHosts($conn,['ns1.unknow.sk','ns2.unknow.sk','ns3.unknow.sk']);
+
+            echo "Get host info\n";
+            getHostInfo($conn, 'ns1.unknow.sk');
+
+            echo "Removing hosts\n";
+            deleteHost($conn, 'ns1.unknow.sk');
+            deleteHost($conn, 'ns2.unknow.sk');
+
+            echo "Checking hosts after delete\n";
+            checkHosts($conn,['ns1.unknow.sk','ns2.unknow.sk','ns3.unknow.sk']);
 
             echo "Creating contact\n";
             $contactid = createcontact($conn, 'admin@unknow.sk','+421.901234567','IT' ,'Unknow.sk' ,'Pod mostom 1' ,'05201' , 'Spišská Nová Ves', 'SK', 'PERS', '1987-06-09');
@@ -642,51 +642,49 @@ try {
                 deleteContact($conn, $contactid);
             }
 
-//            echo "Creating domain\n";
-//            createDomain(
-//                $conn,
-//                $domains[0],
-//                [
-//                    new eppHost('ns1.unknow.sk'),
-//                    new eppHost('ns2.unknow.sk')
-//                ],
-//                $conn->getUsername(),
-//                [
-//                    new eppContactHandle($conn->getUsername(), eppContactHandle::CONTACT_TYPE_ADMIN),
-//                    new eppContactHandle($conn->getUsername(), eppContactHandle::CONTACT_TYPE_TECH),
-//                    new eppContactHandle($conn->getUsername(), eppContactHandle::CONTACT_TYPE_BILLING)
-//                ],
-//                2,
-//                generateValidAuthCode()
-//            );
-//
-//            echo "Updating domain\n";
-//            $updateInfo = new eppDomain($domains[0]);
-//
-//            updateDomain(
-//                $conn,
-//                $domains[0],
-//                null,
-//                null,
-//                $updateInfo,
-//                [
-//                    ['type' => 'abuse', 'id' => $conn->getUsername()]
-//                ],
-//                [
-//                    ['type' => 'abuse', 'id' => $conn->getUsername()]
-//                ]
-//            );
-//
-//            echo "Get domain info\n";
-//            getDomainInfo($conn, $domains[0]); // $domains[0]);
-//
-//            echo "Renewing domain\n";
-//            renewDomain($conn, $domains[0], 1);
-//
-//            echo "Removing domain\n";
-//            deleteDomain($conn, $domains[0]);
+            echo "Creating domain\n";
+            createDomain(
+                $conn,
+                $domains[0],
+                [
+                    new eppHost('ns1.unknow.sk'),
+                    new eppHost('ns2.unknow.sk')
+                ],
+                $conn->getUsername(),
+                [
+                    new eppContactHandle($conn->getUsername(), eppContactHandle::CONTACT_TYPE_ADMIN),
+                    new eppContactHandle($conn->getUsername(), eppContactHandle::CONTACT_TYPE_TECH),
+                    new eppContactHandle($conn->getUsername(), eppContactHandle::CONTACT_TYPE_BILLING)
+                ],
+                2,
+                generateValidAuthCode()
+            );
 
+            echo "Updating domain\n";
+            $updateInfo = new eppDomain($domains[0]);
 
+            updateDomain(
+                $conn,
+                $domains[0],
+                null,
+                null,
+                $updateInfo,
+                [
+                    ['type' => 'abuse', 'id' => $conn->getUsername()]
+                ],
+                [
+                    ['type' => 'abuse', 'id' => $conn->getUsername()]
+                ]
+            );
+
+            echo "Get domain info\n";
+            getDomainInfo($conn, $domains[0]);
+
+            echo "Renewing domain\n";
+            renewDomain($conn, $domains[0], 1);
+
+            echo "Removing domain\n";
+            deleteDomain($conn, $domains[0]);
 
             $conn->logout();
         }

--- a/Registries/sknicEppConnection/sknic.php
+++ b/Registries/sknicEppConnection/sknic.php
@@ -1,0 +1,698 @@
+<?php
+require('../../autoloader.php');
+
+use Metaregistrar\EPP\AuxContactCreateDomainRequest;
+use Metaregistrar\EPP\AuxContactUpdateDomainRequest;
+use Metaregistrar\EPP\eppDeleteContactRequest;
+use Metaregistrar\EPP\eppDeleteDomainRequest;
+use Metaregistrar\EPP\eppDeleteHostRequest;
+use Metaregistrar\EPP\eppHelloRequest;
+use Metaregistrar\EPP\eppHelloResponse;
+use Metaregistrar\EPP\eppInfoContactRequest;
+use Metaregistrar\EPP\eppInfoDomainRequest;
+use Metaregistrar\EPP\eppInfoDomainResponse;
+use Metaregistrar\EPP\eppInfoHostRequest;
+use Metaregistrar\EPP\eppRenewRequest;
+use Metaregistrar\EPP\eppRenewResponse;
+use Metaregistrar\EPP\sknicEppConnection;
+use Metaregistrar\EPP\eppException;
+use Metaregistrar\EPP\eppCheckDomainRequest;
+use Metaregistrar\EPP\eppCheckDomainResponse;
+use Metaregistrar\EPP\eppDomain;
+use Metaregistrar\EPP\eppContact;
+use Metaregistrar\EPP\eppHost;
+use Metaregistrar\EPP\eppContactHandle;
+use Metaregistrar\EPP\eppCheckContactRequest;
+use Metaregistrar\EPP\eppCheckHostRequest;
+use Metaregistrar\EPP\eppCreateHostRequest;
+use Metaregistrar\EPP\eppPollRequest;
+use Metaregistrar\EPP\eppPollResponse;
+use Metaregistrar\EPP\sknicEppContactPostalInfo;
+use Metaregistrar\EPP\sknicEppCreateContactRequest;
+use Metaregistrar\EPP\sknicEppUpdateContactRequest;
+
+/**
+ * Get server information.
+ *
+ * @param sknicEppConnection $conn
+ */
+function hello($conn): array
+{
+    /* @var $conn Metaregistrar\EPP\sknicEppConnection */
+
+    $return = [
+        'server_name' => null,
+        'server_date' => null,
+        'languages' => [],
+        'versions' => [],
+        'services' => [],
+        'extensions' => [],
+    ];
+
+    try {
+        $greeting = new eppHelloRequest;
+        if ((($response = $conn->request($greeting)) instanceof eppHelloResponse) && ($response->Success())) {
+            $return['server_name'] = $response->getServerName();
+            $return['server_date'] = $response->getServerDate();
+            $return['languages'] = $response->getLanguages();
+            $return['versions'] = $response->getVersions();
+            $return['services'] = $response->getServices();
+            $return['extensions'] = $response->getExtensions();
+        }
+    } catch (eppException $e) {
+        echo $e->getMessage() . "\n";
+    }
+
+    return $return;
+}
+
+/**
+ * Check for poll messages.
+ *
+ * @param sknicEppConnection $conn
+ */
+function checkPoll($conn)
+{
+    /* @var $conn Metaregistrar\EPP\sknicEppConnection */
+    try {
+        $poll = new eppPollRequest(eppPollRequest::POLL_REQ);
+        if ($response = $conn->request($poll)) {
+            /* @var $response eppPollResponse */
+            echo "You have ".$response->getMessageCount()." poll messages waiting\n";
+        }
+    } catch (eppException $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+/**
+ * Check domain availability.
+ *
+ * @param sknicEppConnection $conn
+ * @param array $domains of domain names
+ */
+function checkDomains($conn, array $domains)
+{
+    /* @var $conn Metaregistrar\EPP\sknicEppConnection */
+    try {
+        // Create request to be sent to EPP service
+        $check = new eppCheckDomainRequest($domains,false);
+        // Write request to EPP service, read and check the results
+        if ($response = $conn->request($check)) {
+            /* @var $response eppCheckDomainResponse */
+            // Walk through the results
+            $checks = $response->getCheckedDomains();
+            foreach ($checks as $check) {
+                echo $check['domainname'] . " is " . ($check['available'] ? 'free' : 'taken');
+                if ($check['available']) {
+                    echo ' (' . $check['reason'] .')';
+                }
+                echo "\n";
+            }
+        }
+    } catch (eppException $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+/**
+ * Check if a contact exists.
+ *
+ * @param sknicEppConnection $conn
+ * @param string $contactid
+ */
+function checkContact($conn, string $contactid)
+{
+    /* @var $conn Metaregistrar\EPP\sknicEppConnection */
+    try {
+        $check = new eppCheckContactRequest(new eppContactHandle($contactid),false);
+        if ($response = $conn->request($check)) {
+            /* @var $response Metaregistrar\EPP\eppCheckContactResponse */
+            //$response->dumpContents();
+            $checks = $response->getCheckedContacts();
+            foreach ($checks as $contact => $check) {
+                echo "Contact $contact " . ($check ? 'does not exist' : 'exists') . "\n";
+            }
+        }
+    } catch (eppException $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+/**
+ * Check if a host exists.
+ *
+ * @param sknicEppConnection $conn
+ * @param array $hosts
+ * @return bool|null
+ */
+function checkHosts($conn, array $hosts)
+{
+    /* @var $conn Metaregistrar\EPP\sknicEppConnection */
+    try {
+        $checkhost = array();
+        foreach ($hosts as $host) {
+            $checkhost[] = new eppHost($host);
+        }
+        $check = new eppCheckHostRequest($checkhost,false);
+        if ($response = $conn->request($check)) {
+            /* @var $response Metaregistrar\EPP\eppCheckHostResponse */
+            $checks = $response->getCheckedHosts();
+            $allchecksok = true;
+            foreach ($checks as $hostname => $check) {
+                echo "$hostname " . ($check ? 'does not exist' : 'exists') . "\n";
+                if ($check) {
+                    $allchecksok = false;
+                }
+            }
+            return $allchecksok;
+        }
+    } catch (eppException $e) {
+        echo $e->getMessage() . "\n";
+    }
+    return null;
+}
+
+/**
+ * Get host information.
+ *
+ * @param sknicEppConnection $conn
+ * @param string $hostName
+ */
+function getHostInfo($conn, string $hostName)
+{
+    /* @var $conn Metaregistrar\EPP\sknicEppConnection */
+    try {
+        $infoRequest = new eppInfoHostRequest(new eppHost($hostName));
+
+        if ($response = $conn->request($infoRequest)) {
+            /* @var $response Metaregistrar\EPP\eppInfoHostResponse */
+            $info = $response->getHost();
+            echo "Host: " . $info->getHostname() . " has " . $info->getIpAddressCount() . " ip addresses\n";
+        }
+    } catch (eppException $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+/**
+ * Create a new host.
+ *
+ * @param sknicEppConnection $conn
+ * @param string $hostName
+ * @param array $ipAddresses
+ */
+function createHost($conn, string $hostName, array $ipAddresses = [])
+{
+    /* @var $conn Metaregistrar\EPP\sknicEppConnection */
+    try {
+        $create = new eppCreateHostRequest(new eppHost($hostName, $ipAddresses),false);
+        if ($response = $conn->request($create)) {
+            /* @var $response Metaregistrar\EPP\eppCreateHostResponse */
+            echo "Host created on " . $response->getHostCreateDate() . " with name " . $response->getHostName() . "\n";
+        }
+    } catch (eppException $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+/**
+ * Delete a host.
+ *
+ * @param sknicEppConnection $conn
+ * @param string $hostName
+ */
+function deleteHost($conn, string $hostName)
+{
+    /* @var $conn Metaregistrar\EPP\sknicEppConnection */
+    try {
+        $host = new eppHost($hostName);
+        $deleteRequest = new eppDeleteHostRequest($host);
+
+        if ($conn->request($deleteRequest)) {
+            /* @var $response Metaregistrar\EPP\eppDeleteResponse */
+            echo "Host " . $hostName . " deleted\n";
+        }
+    } catch (eppException $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+/**
+ * Get domain info.
+ *
+ * @param sknicEppConnection $conn
+ * @param string $domain
+ */
+function getDomainInfo($conn, string $domain)
+{
+    /* @var $conn Metaregistrar\EPP\sknicEppConnection */
+    try {
+        $infoRequest = new eppInfoDomainRequest(new eppDomain($domain));
+
+        if ($response = $conn->request($infoRequest)) {
+            /* @var $response Metaregistrar\EPP\AuxContactInfoDomainResponse */
+            $info = $response->getDomain();
+            if (method_exists($response, 'getRgpStatuses')) {
+                /* @var $response Metaregistrar\EPP\eppRgpInfoDomainResponse */
+                $rgpStatuses = $response->getRgpStatuses();
+            } else {
+                $rgpStatuses = [];
+                $xpath = $response->xPath();
+                $result = $xpath->query('/epp:epp/epp:response/epp:extension/rgp:infData/rgp:rgpStatus/@s');
+                foreach ($result as $status) {
+                    $rgpStatuses[] = $status->nodeValue;
+                }
+            }
+
+            echo "Domain: " . $info->getDomainname() . " has " . $info->getContactLength() . " contacts + RGP statuses: " . implode(',', $rgpStatuses) .  "\n";
+        }
+    } catch (eppException $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+/**
+ * Create a new domain.
+ *
+ * @param sknicEppConnection $conn
+ * @param string $domain
+ * @param array $ns
+ * @param string $registrant
+ * @param array $contacts
+ * @param int $period
+ * @param null $authCode
+ * @param null|string $abuseId
+ * @param null|string $dnsOperatorId
+ */
+function createDomain($conn, string $domain, array $ns, string $registrant, array $contacts, int $period = 1, $authCode = null, $abuseId = null, $dnsOperatorId = null)
+{
+    /* @var $conn Metaregistrar\EPP\sknicEppConnection */
+    try {
+        // Prepare auxiliary contacts
+        $auxContacts = [];
+
+        if ($abuseId) {
+            $auxContacts[] = ['type' => 'abuse', 'id' => $abuseId];
+        }
+
+        if ($dnsOperatorId) {
+            $auxContacts[] = ['type' => 'dns-operator', 'id' => $dnsOperatorId];
+        }
+
+        $domain = new eppDomain($domain, $registrant, $contacts, $ns, $period, $authCode);
+        $domainRequest = new AuxContactCreateDomainRequest($domain,false,false, false, $auxContacts);
+        $domainRequest->dumpContents();
+        if ($response = $conn->request($domainRequest)) {
+            /* @var $response Metaregistrar\EPP\eppCreateDomainResponse */
+            echo "Domain " . $response->getDomainName() . " created on " . $response->getDomainCreateDate() . ", expiration date is " . $response->getDomainExpirationDate() . "\n";
+        }
+    } catch (eppException $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+/**
+ * Update a new domain.
+ *
+ * @param sknicEppConnection $conn
+ * @param string $domain
+ * @param null|eppDomain $addInfo
+ * @param null|eppDomain $removeInfo
+ * @param null|eppDomain $updateInfo
+ * @param array $addContacts
+ * @param array $removeContacts
+ */
+function updateDomain($conn, string $domain, $addInfo = null, $removeInfo = null, $updateInfo = null, $addContacts = [], $removeContacts = [])
+{
+    /* @var $conn Metaregistrar\EPP\sknicEppConnection */
+    try {
+        $domainRequest = new AuxContactUpdateDomainRequest(new eppDomain($domain),$addInfo, $removeInfo, $updateInfo, false, false, true, $addContacts, $removeContacts);
+        $domainRequest->dumpContents();
+        if ($response = $conn->request($domainRequest)) {
+            /* @var $response Metaregistrar\EPP\eppUpdateDomainResponse */
+            echo "Domain " . $response->getResultDomainName() . " updated\n";
+        }
+    } catch (eppException $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+/**
+ * Delete a domain.
+ *
+ * @param sknicEppConnection $conn
+ * @param string $domain
+ */
+function deleteDomain($conn, string $domain)
+{
+    try {
+        $deleteRequest = new eppDeleteDomainRequest(new eppDomain($domain));
+
+        if ($conn->request($deleteRequest)) {
+            /* @var $response Metaregistrar\EPP\eppDeleteResponse */
+            echo "Domain " . $domain . " deleted\n";
+        }
+    } catch (eppException $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+/**
+ * Renew a domain.
+ *
+ * @param sknicEppConnection $conn
+ * @param string $domainname
+ * @param int $years
+ */
+function renewDomain($conn, string $domainname, int $years = 1)
+{
+    try {
+        $domain = new eppDomain($domainname);
+        $domain->setPeriod($years);
+        $domain->setPeriodUnit('y');
+        $info = new eppInfoDomainRequest($domain);
+        if ($response = $conn->request($info)) {
+            /* @var $response eppInfoDomainResponse */
+            $expdate = date('Y-m-d', strtotime($response->getDomainExpirationDate()));
+            $renew = new eppRenewRequest($domain, $expdate);
+            // Write request to EPP service, read and check the results
+            /* @var $response eppRenewResponse */
+            if (($response = $conn->request($renew)) && (int) $response->getResultCode() === 1000) {
+                echo "Domain " . $response->getDomainName() . " has been renewed for ".$years." year(s) and has expiration date ".$response->getDomainExpirationDate()."\n";
+            }
+        }
+    } catch (eppException $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+/**
+ * Get contact information.
+ *
+ * @param sknicEppConnection $conn
+ * @param string $contactId
+ */
+function getContactInfo($conn, string $contactId)
+{
+    try {
+        $infoRequest = new eppInfoContactRequest(new eppContactHandle($contactId));
+
+        if ($response = $conn->request($infoRequest)) {
+            /* @var $response Metaregistrar\EPP\eppInfoContactResponse */
+            $info = $response->getContact();
+            echo "Contact: " . $info->getType() . " has " . $info->getId() . "\n";
+        }
+    } catch (eppException $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+/**
+ * Create a new contact.
+ *
+ * @param sknicEppConnection $conn
+ * @param string $email
+ * @param string $telephone
+ * @param string $name
+ * @param string $org
+ * @param string $street
+ * @param string $postcode
+ * @param string $city
+ * @param string $country
+ * @param string $type
+ * @param string $uid
+ * @return string|null
+ */
+function createContact($conn, string $email, string $telephone, string $name, string $org, string $street, string $postcode, string $city, string $country, string $type, string $uid)
+{
+    try {
+        $telephone = preg_replace('/^\+([0-9]{1,3})([0-9]+)$/', '+$1.$2', $telephone);
+
+        $postalInfo = new sknicEppContactPostalInfo($name, $city, $country, $org, $street, '', $postcode, eppContact::TYPE_AUTO, $type, $uid);
+        $contact = new eppContact($postalInfo, $email, $telephone, null, generateValidAuthCode());
+        $contactRequest = new sknicEppCreateContactRequest($contact, false);
+
+        $contactRequest->dumpContents();
+        if ($response = $conn->request($contactRequest)) {
+            /* @var $response Metaregistrar\EPP\eppCreateContactResponse */
+            echo "Created " . $response->getContactId() . "\n";
+
+            return $response->getContactId();
+        }
+    } catch (eppException $e) {
+        echo $e->getMessage() . "\n";
+    }
+
+    return null;
+}
+
+/**
+ * Update an existing contact.
+ *
+ * @param sknicEppConnection $conn
+ * @param string $email
+ * @param string $telephone
+ * @param string $name
+ * @param string $org
+ * @param string $street
+ * @param string $postcode
+ * @param string $city
+ * @param string $country
+ * @param string $type
+ * @param string $uid
+ */
+function updateContact($conn, string $contactid, string $email, string $telephone, string $name, string $org, string $street, string $postcode, string $city, string $country, string $type, string $uid)
+{
+    try {
+        $telephone = preg_replace('/^\+([0-9]{1,3})([0-9]+)$/', '+$1.$2', $telephone);
+
+        $postalInfo = new sknicEppContactPostalInfo($name, $city, $country, $org, $street, '', $postcode, eppContact::TYPE_AUTO, $type, $uid);
+        $updateInfo = new eppContact($postalInfo, $email, $telephone, null, generateValidAuthCode());
+        $contact = new eppContactHandle($contactid);
+        $contactRequest = new sknicEppUpdateContactRequest($contact, null, null, $updateInfo, false);
+
+        if ($response = $conn->request($contactRequest)) {
+            /* @var $response Metaregistrar\EPP\eppUpdateContactResponse */
+            echo "Contact " . $response->getResultContactId() . " updated\n";
+        }
+    } catch (eppException $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+/**
+ * Delete a contact.
+ *
+ * @param sknicEppConnection $conn
+ * @param string $contactId
+ */
+function deleteContact($conn, string $contactId)
+{
+    try {
+        $deleteRequest = new eppDeleteContactRequest(new eppContactHandle($contactId));
+
+        if ($conn->request($deleteRequest)) {
+            /* @var $response Metaregistrar\EPP\eppDeleteResponse */
+            echo "Contact " . $contactId . " deleted\n";
+        }
+    } catch (eppException $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+/**
+ * Generate a valid authInfo code for EPP
+ * - At least 16 characters long
+ * - Contains at least one non-alphanumeric character
+ *
+ * @param  int  $length  Minimum length of the authInfo code
+ * @return string Valid authInfo code
+ */
+function generateValidAuthCode(int $length = 16): string
+{
+    // Special characters, numbers, lowercase and uppercase characters
+    $specialChars = '!@#$%^&*()-_=+{}[]|:;<>,.?/~';
+    $numbers = '0123456789';
+    $lowercase = 'abcdefghijklmnopqrstuvwxyz';
+    $uppercase = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+    // Ensure minimum length is at least 4 to fit one of each type
+    if ($length < 4) {
+        throw new \InvalidArgumentException('Length must be at least 4 to accommodate all required character types.');
+    }
+
+    // Generate the required characters
+    $specialChar = $specialChars[random_int(0, strlen($specialChars) - 1)];
+    $number = $numbers[random_int(0, strlen($numbers) - 1)];
+    $lower = $lowercase[random_int(0, strlen($lowercase) - 1)];
+    $upper = $uppercase[random_int(0, strlen($uppercase) - 1)];
+
+    // Generate the remaining random characters (length - 4) from all characters
+    $remainingLength = $length - 4;
+
+    $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    $charactersLength = strlen($characters);
+    $remainingString = '';
+    for ($i = 0; $i < $remainingLength; $i++) {
+        $remainingString .= $characters[random_int(0, $charactersLength - 1)];
+    }
+
+    // Combine all characters
+    $authCode = $lower.$upper.$number.$specialChar.$remainingString;
+
+    // Shuffle the result to randomize the character positions
+    return str_shuffle($authCode);
+}
+
+/*
+ * Generate random domain names for testing
+ * You can specify the number of domains to generate and an array of existing domains to avoid duplicates
+ */
+function generateRandomDomainSK($count = 1, $ext = '.sk') {
+    $domains = [];
+    $consonants = ['b', 'c', 'd', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n', 'p', 'r', 's', 't', 'v', 'w', 'x', 'z'];
+    $vowels = ['a', 'e', 'i', 'o', 'u', 'y'];
+
+    while (count($domains) < $count) {
+        $length = random_int(5, 12);
+        $domain = '';
+
+        // Generate domain with alternating consonants and vowels for better pronounceability
+        for ($i = 0; $i < $length; $i++) {
+            $domain .= ($i % 2 == 0) ? $consonants[array_rand($consonants)] : $vowels[array_rand($vowels)];
+        }
+
+        $domainWithTLD = $domain . $ext;
+
+        // Check if domain already exists in our list or in existing domains
+        if (!in_array($domainWithTLD, $domains)) {
+            $domains[] = $domainWithTLD;
+        }
+    }
+
+    return $domains;
+}
+
+
+/**
+ * This script demonstrates how to use the EPP client to check domain availability,
+ * create a contact, and create a domain with specified nameservers.
+ *
+ * It uses the Metaregistrar EPP client library.
+ *
+ * Usage:
+ * php sknic.php
+ */
+
+$domains = generateRandomDomainSK();
+
+/*
+ * This script checks for the availability of domain names
+ * You can specify multiple domain names to be checked
+ */
+try {
+
+    if ($conn = sknicEppConnection::create('settings.ini', false)) {
+        // Connect and login to the EPP server
+        if ($conn->login()) {
+//            echo "Hellol\n";
+//            $hello = hello($conn);
+//            var_dump($hello);
+
+            echo "Checking poll\n";
+            checkPoll($conn);
+
+//            echo "Checking " . count($domains) . " domain names\n";
+//            checkDomains($conn, $domains);
+//
+//            echo "Checking contact\n";
+//            checkContact($conn,'UBOM-0334');
+//
+//            echo "Checking hosts\n";
+//            checkHosts($conn,['ns1.unknow.sk','ns2.unknow.sk','ns3.unknow.sk']);
+
+//            echo "Creating hosts\n";
+//            $host_id1 = createHost($conn,'ns1.unknow.sk', ['1.2.3.4']);
+//            $host_id2 = createHost($conn,'ns2.unknow.sk', ['5.6.7.8']);
+//
+//            echo "Checking hosts after create\n";
+//            checkHosts($conn,['ns1.unknow.sk','ns2.unknow.sk','ns3.unknow.sk']);
+//
+//            echo "Get host info\n";
+//            getHostInfo($conn, 'ns1.unknow.sk');
+
+//            echo "Removing hosts\n";
+//            deleteHost($conn, 'ns1.unknow.sk');
+//            deleteHost($conn, 'ns2.unknow.sk');
+//
+//            echo "Checking hosts after delete\n";
+//            checkHosts($conn,['ns1.unknow.sk','ns2.unknow.sk','ns3.unknow.sk']);
+
+            echo "Creating contact\n";
+            $contactid = createcontact($conn, 'admin@unknow.sk','+421.901234567','IT' ,'Unknow.sk' ,'Pod mostom 1' ,'05201' , 'Spišská Nová Ves', 'SK', 'PERS', '1987-06-09');
+
+            if ($contactid) {
+                echo "Get contact info\n";
+                getContactInfo($conn, $contactid);
+
+                echo "Updating contact\n";
+                updateContact($conn, $contactid, 'admin@unknow.sk','+421.901234567','IT' ,'Unknow.sk' ,'Pod mostom 1' ,'05201' , 'Spišská Nová Ves', 'SK', 'PERS', '1987-06-05');
+
+                echo "Removing contact\n";
+                deleteContact($conn, $contactid);
+            }
+
+//            echo "Creating domain\n";
+//            createDomain(
+//                $conn,
+//                $domains[0],
+//                [
+//                    new eppHost('ns1.unknow.sk'),
+//                    new eppHost('ns2.unknow.sk')
+//                ],
+//                $conn->getUsername(),
+//                [
+//                    new eppContactHandle($conn->getUsername(), eppContactHandle::CONTACT_TYPE_ADMIN),
+//                    new eppContactHandle($conn->getUsername(), eppContactHandle::CONTACT_TYPE_TECH),
+//                    new eppContactHandle($conn->getUsername(), eppContactHandle::CONTACT_TYPE_BILLING)
+//                ],
+//                2,
+//                generateValidAuthCode()
+//            );
+//
+//            echo "Updating domain\n";
+//            $updateInfo = new eppDomain($domains[0]);
+//
+//            updateDomain(
+//                $conn,
+//                $domains[0],
+//                null,
+//                null,
+//                $updateInfo,
+//                [
+//                    ['type' => 'abuse', 'id' => $conn->getUsername()]
+//                ],
+//                [
+//                    ['type' => 'abuse', 'id' => $conn->getUsername()]
+//                ]
+//            );
+//
+//            echo "Get domain info\n";
+//            getDomainInfo($conn, $domains[0]); // $domains[0]);
+//
+//            echo "Renewing domain\n";
+//            renewDomain($conn, $domains[0], 1);
+//
+//            echo "Removing domain\n";
+//            deleteDomain($conn, $domains[0]);
+
+
+
+            $conn->logout();
+        }
+    }
+} catch (eppException $e) {
+    echo "ERROR: " . $e->getMessage()."\n";
+    echo $e->getLastCommand();
+    echo "\n\n";
+}


### PR DESCRIPTION
Adding support for SK-NIC register, integration according to the official manual [SK-NIC EPP documentation](https://sk-nic.sk/en/epp-documentation/#extensions).

It use DNSSEC and RGP, but i've added 2 new extensions: 
- auxcontact-0.1
- sk-contact-ident-0.2

Next i've added new config "certificatekey", it's because SK-NIC supports SSL certificates with local_pk (not passphrase).

All commands tested via /Registries/sknicEppConnection/sknic.php