### PR TITLE
Add possibility to specify source IP address

### DIFF
--- a/Protocols/EPP/eppConnection.php
+++ b/Protocols/EPP/eppConnection.php
@@ -187,6 +187,11 @@ class eppConnection {
     /**
      * @var null|string
      */
+    protected $sourceIpAddr = null;
+
+    /**
+     * @var null|string
+     */
     protected $logFile = null;
 
     /**
@@ -373,6 +378,11 @@ class eppConnection {
                 } else {
                     stream_context_set_option($context, 'ssl', 'verify_peer', $this->verify_peer);
                 }
+            }
+            if ($this->sourceIpAddr && filter_var($this->sourceIpAddr, FILTER_VALIDATE_IP)) {
+                stream_context_set_option($context, 'socket', 'bindto', $this->sourceIpAddr . ":0");
+            } else if (defined("METAREGISTRAR_EPP_SOURCE_IPADDR") && filter_var(METAREGISTRAR_EPP_SOURCE_IPADDR, FILTER_VALIDATE_IP)) {
+                stream_context_set_option($context, 'socket', 'bindto', METAREGISTRAR_EPP_SOURCE_IPADDR . ":0");
             }
             $this->sslContext = $context;
         }
@@ -1294,6 +1304,15 @@ class eppConnection {
      */
     public function setConnectionComment($connectionComment) {
         $this->connectionComment = $connectionComment;
+        return $this;
+    }
+
+    /**
+     * @param null|string $sourceIpAddr
+     * @return eppConnection
+     */
+    public function setsourceIpAddr($sourceIpAddr) {
+        $this->sourceIpAddr = $sourceIpAddr;
         return $this;
     }
 


### PR DESCRIPTION
On an Ubuntu machine, the `socket_connect()` (which is using `connect()` in C) seems to open the socket from a random IP address, which is a problem if you have multiple IP addresses and a whitelist at the registry. This PR introduces a method to specify a certain IP address to connect from (i.e. having the socket bound to this local IP address). I also considered a fallback constant helpful, so one can define a default source IP address for a whole project.