### PR TITLE
added rrpproxy ext response to get contact verified/validation in contact info…

### DIFF
--- a/Protocols/EPP/eppExtensions/keysys-1.0/eppResponses/rrpproxyEppInfoContactResponse.php
+++ b/Protocols/EPP/eppExtensions/keysys-1.0/eppResponses/rrpproxyEppInfoContactResponse.php
@@ -1,0 +1,49 @@
+<?php
+namespace Metaregistrar\EPP;
+
+/*
+ *  <extension>
+      <keysys:resData xmlns:keysys="http://www.key-systems.net/epp/keysys-1.0">
+        <keysys:contactInfData>
+          <keysys:validated>1</keysys:validated>
+          <keysys:verified>1</keysys:verified>
+        </keysys:contactInfData>
+      </keysys:resData>
+    </extension>
+ */
+
+class rrpproxyEppInfoContactResponse extends eppInfoContactResponse {
+    function __construct() {
+        parent::__construct();
+    }
+
+
+    /**
+     *
+     * @return bool|null
+     */
+    public function getValidated() {
+        $xpath = $this->xPath();
+        $result = $xpath->query('/epp:epp/epp:response/epp:extension/keysys:resData/keysys:contactInfData/keysys:validated');
+        if ($result->length > 0) {
+            return $result->item(0)->nodeValue == '1' ? true : false;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     *
+     * @return bool|null
+     */
+    public function getVerified() {
+        $xpath = $this->xPath();
+        $result = $xpath->query('/epp:epp/epp:response/epp:extension/keysys:resData/keysys:contactInfData/keysys:verified');
+        if ($result->length > 0) {
+            return $result->item(0)->nodeValue == '1' ? true : false;
+        } else {
+            return null;
+        }
+    }
+}
+

--- a/Protocols/EPP/eppExtensions/keysys-1.0/includes.php
+++ b/Protocols/EPP/eppExtensions/keysys-1.0/includes.php
@@ -15,3 +15,6 @@ $this->addCommandResponse('Metaregistrar\EPP\rrpproxyEppRenewalmodeRequest', 'Me
 
 include_once(dirname(__FILE__) . '/eppRequests/rrpproxyEppTransferDomainRequest.php');
 $this->addCommandResponse('Metaregistrar\EPP\rrpproxyEppTransferDomainRequest', 'Metaregistrar\EPP\eppTransferResponse');
+
+include_once(dirname(__FILE__) . '/eppResponses/rrpproxyEppInfoContactResponse.php');
+$this->addCommandResponse('Metaregistrar\EPP\eppInfoContactRequest', 'Metaregistrar\EPP\rrpproxyEppInfoContactResponse');


### PR DESCRIPTION
Rrrpproxy returns contact verification and validation status on EPP contact info response. This change will allow to get `verified` and `validated` on contact info response.