### PR TITLE
Add/fix type hints in eppContact

### DIFF
--- a/Protocols/EPP/eppData/eppContact.php
+++ b/Protocols/EPP/eppData/eppContact.php
@@ -39,24 +39,32 @@ class eppContact {
 
     /** @var string */
     private $id;
+    /** @var array<eppContactPostalInfo> */
     private $postalInfo = array();
+    /** @var string|null */
     private $voice=null;
+    /** @var string|null */
     private $fax=null;
+    /** @var string|null */
     private $email=null;
+    /** @var string|null */
     private $password=null;
+    /** @var array<string>|string|null */
     private $status=null;
+    /** @var string */
     private $type = self::TYPE_AUTO;
+    /** @var string|null */
     private $disclose = null;
 
 
     /**
      *
-     * @param eppContactPostalInfo $postalInfo
-     * @param string $email
-     * @param string $voice
-     * @param string $fax
-     * @param string $password
-     * @param string $status
+     * @param eppContactPostalInfo|array<eppContactPostalInfo>|null $postalInfo
+     * @param string|null $email
+     * @param string|null $voice
+     * @param string|null $fax
+     * @param string|null $password
+     * @param array<string>|string|null $status
      */
     public function __construct($postalInfo = null, $email = null, $voice = null, $fax = null, $password = null, $status = null) {
         if ($postalInfo instanceof eppContactPostalInfo) {
@@ -79,19 +87,33 @@ class eppContact {
 
     }
 
+    /**
+     * @param string $disclose
+     * @return void
+     */
     public function setDisclose($disclose) {
         $this->disclose = $disclose;
     }
 
+    /**
+     * @return string|null
+     */
     public function getDisclose() {
         return $this->disclose;
     }
 
 
+    /**
+     * @param string $type
+     * @return void
+     */
     public function setType($type) {
         $this->type = $type;
     }
 
+    /**
+     * @return string
+     */
     public function getType() {
         return $this->type;
     }
@@ -121,7 +143,7 @@ class eppContact {
      * Retrieve a postalInfo object by number
      *
      * @param int $line
-     * @return eppContactPostalInfo
+     * @return eppContactPostalInfo|null
      */
     public function getPostalInfo($line) {
         if ($this->postalInfo[$line]) {
@@ -133,7 +155,8 @@ class eppContact {
 
     /**
      * Sets the status
-     * @param string $status
+     * @param array<string>|string $status
+     * @return void
      */
     public function setStatus($status) {
         if (is_array($status)) {
@@ -147,7 +170,7 @@ class eppContact {
 
     /**
      * Sets the status
-     * @return string status
+     * @return array<string>|string|null
      */
     public function getStatus() {
         return $this->status;
@@ -189,7 +212,7 @@ class eppContact {
 
     /**
      * Gets the password
-     * @return string
+     * @return string|null
      */
     public function getPassword() {
         return $this->password;
@@ -197,7 +220,7 @@ class eppContact {
 
     /**
      * Sets the phone number
-     * @param int $voice
+     * @param string $voice
      * @return void
      */
     public function setVoice($voice) {
@@ -214,7 +237,7 @@ class eppContact {
 
     /**
      * Sets the fax number
-     * @param int $fax
+     * @param string $fax
      * @return void
      */
     public function setFax($fax) {
@@ -223,7 +246,7 @@ class eppContact {
 
     /**
      * Gets the fax number
-     * @return string
+     * @return string|null
      */
     public function getFax() {
         return $this->fax;
@@ -231,8 +254,8 @@ class eppContact {
 
     /**
      * Formats the phone number according to SIDN formatting rules
-     * @param int $number
-     * @return string
+     * @param string $number
+     * @return string|null
      * @throws eppException
      */
     protected function validatePhoneNumber($number) {


### PR DESCRIPTION
I stumbled over the obviously wrong return type hint `null` for `eppContact::getId()`.

This PR adds/fixes the other type hints in this class as well.