### PR TITLE
Fix verisignEppCheckHostRequest constructor to allow same args as parent class

### DIFF
--- a/Protocols/EPP/eppExtensions/verisign/eppRequests/verisignEppCheckHostRequest.php
+++ b/Protocols/EPP/eppExtensions/verisign/eppRequests/verisignEppCheckHostRequest.php
@@ -3,13 +3,8 @@ namespace Metaregistrar\EPP;
 
 class verisignEppCheckHostRequest extends eppCheckHostRequest {
     use verisignEppExtension;
-    /**
-     * verisignEppCheckHostRequest constructor.
-     *
-     * @param eppHost $host
-     */
-    public function __construct(eppHost $host) {
-        parent::__construct($host);
+    public function __construct($checkrequest) {
+        parent::__construct($checkrequest);
         //add namestore extension
         $this->addNamestore();
         $this->addSessionId();


### PR DESCRIPTION
At this moment verisignEppCheckHostRequest constructor narrows down its argument types from list of hosts (list of strings) to just a single eppHost object, compared to the parent class eppCheckHostRequest. This change allows to use list of host strings in verisignEppCheckHostRequest making its interface compatible with the parent class.