### PR TITLE
Fix curl_close() deprecation warning in PHP 8.5

### DIFF
--- a/Protocols/EPP/eppHttpConnection.php
+++ b/Protocols/EPP/eppHttpConnection.php
@@ -52,7 +52,7 @@ class eppHttpConnection extends eppConnection {
 
     public function __destruct() {
         parent::__destruct();
-        if ($this->ch) {
+        if ($this->ch && PHP_VERSION_ID < 80000) {
             curl_close($this->ch);
         }
     }

--- a/Registries/cnisTmchConnection/tmchConnection.php
+++ b/Registries/cnisTmchConnection/tmchConnection.php
@@ -31,7 +31,9 @@ class cnisTmchConnection extends tmchConnection {
             throw new tmchException("Empty output received from CNIS service");
         }
         $this->setLastInfo(curl_getinfo($ch));
-        curl_close($ch);
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($ch);
+        }
         if (strpos($output,'404 Not Found')!==false)
         {
             throw new tmchException("Requested URL was not found on this server");

--- a/Registries/dnlTmchConnection/tmchConnection.php
+++ b/Registries/dnlTmchConnection/tmchConnection.php
@@ -15,7 +15,9 @@ class dnlTmchConnection extends tmchConnection {
             throw new tmchException(curl_error($ch));
         }
         $this->setLastinfo(curl_getinfo($ch));
-        curl_close($ch);
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($ch);
+        }
         return explode("\n", $output);
     }
 }


### PR DESCRIPTION
`curl_close()` is no-op since PHP 8.0 and got deprecated in PHP 8.5: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_no-op_functions_from_the_resource_to_object_conversion

With this PR it is only called on PHP < 8.0