### PR TITLE
Fix DnsBe response constructors

### DIFF
--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppCheckDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppCheckDomainResponse.php
@@ -1,10 +1,5 @@
 <?php
+
 namespace Metaregistrar\EPP;
-class dnsbeEppCheckDomainResponse extends eppCheckDomainResponse {
-    function __construct() {
-        parent::__construct();
-    }
 
-
-
-}
+class dnsbeEppCheckDomainResponse extends eppCheckDomainResponse {}

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppCreateContactResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppCreateContactResponse.php
@@ -1,8 +1,5 @@
 <?php
-namespace Metaregistrar\EPP;
-class dnsbeEppCreateContactResponse extends eppCreateContactResponse {
-    function __construct() {
-        parent::__construct();
-    }
 
-}
+namespace Metaregistrar\EPP;
+
+class dnsbeEppCreateContactResponse extends eppCreateContactResponse {}

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppCreateDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppCreateDomainResponse.php
@@ -1,8 +1,5 @@
 <?php
-namespace Metaregistrar\EPP;
-class dnsbeEppCreateDomainResponse extends eppCreateDomainResponse {
-    function __construct() {
-        parent::__construct();
-    }
 
-}
+namespace Metaregistrar\EPP;
+
+class dnsbeEppCreateDomainResponse extends eppCreateDomainResponse {}

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppCreateResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppCreateResponse.php
@@ -1,8 +1,5 @@
 <?php
-namespace Metaregistrar\EPP;
-class dnsbeEppCreateResponse extends eppCreateResponse {
-    function __construct() {
-        parent::__construct();
-    }
 
-}
+namespace Metaregistrar\EPP;
+
+class dnsbeEppCreateResponse extends eppCreateResponse {}

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppDeleteDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppDeleteDomainResponse.php
@@ -1,8 +1,5 @@
 <?php
-namespace Metaregistrar\EPP;
-class dnsbeEppDeleteDomainResponse extends eppResponse {
-    function __construct() {
-        parent::__construct();
-    }
 
-}
+namespace Metaregistrar\EPP;
+
+class dnsbeEppDeleteDomainResponse extends eppResponse {}

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppInfoContactResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppInfoContactResponse.php
@@ -1,21 +1,19 @@
 <?php
+
 namespace Metaregistrar\EPP;
 
 /**
  * Class dnsbeEppInfoDomainResponse
  * @package Metaregistrar\EPP
  */
-class dnsbeEppInfoContactResponse extends eppInfoContactResponse {
-    function __construct() {
-        parent::__construct();
-    }
-
-
+class dnsbeEppInfoContactResponse extends eppInfoContactResponse
+{
     /**
      * Retrieve the vat registered number of the contact
      * @return string|null
      */
-    public function getVat() {
+    public function getVat()
+    {
         $xpath = $this->xPath();
         $result = $xpath->query('/epp:epp/epp:response/epp:extension/dnsbe:ext/dnsbe:infData/dnsbe:contact/dnsbe:vat');
         if ($result->length > 0) {
@@ -25,33 +23,33 @@ class dnsbeEppInfoContactResponse extends eppInfoContactResponse {
         }
     }
 
+    /**
+     * Retrieve the the type of contact. Specific to DNS.be.
+     * @return string|null
+     */
+    public function getDnsBeContactType()
+    {
+        $xpath = $this->xPath();
+        $result = $xpath->query('/epp:epp/epp:response/epp:extension/dnsbe:ext/dnsbe:infData/dnsbe:contact/dnsbe:type');
+        if ($result->length > 0) {
+            return $result->item(0)->nodeValue;
+        } else {
+            return null;
+        }
+    }
 
     /**
      * Retrieve the the type of contact. Specific to DNS.be.
      * @return string|null
      */
-    public function getDnsBeContactType() {
+    public function getLang()
+    {
         $xpath = $this->xPath();
-        $result = $xpath->query('/epp:epp/epp:response/epp:extension/dnsbe:ext/dnsbe:infData/dnsbe:contact/dnsbe:type');
+        $result = $xpath->query('/epp:epp/epp:response/epp:extension/dnsbe:ext/dnsbe:infData/dnsbe:contact/dnsbe:lang');
         if ($result->length > 0) {
-           return $result->item(0)->nodeValue;
+            return $result->item(0)->nodeValue;
         } else {
             return null;
         }
     }
-   /**
-    * Retrieve the the type of contact. Specific to DNS.be.
-    * @return string|null
-    */
-   public function getLang() {
-      $xpath = $this->xPath();
-      $result = $xpath->query('/epp:epp/epp:response/epp:extension/dnsbe:ext/dnsbe:infData/dnsbe:contact/dnsbe:lang');
-      if ($result->length > 0) {
-         return $result->item(0)->nodeValue;
-      } else {
-         return null;
-      }
-   }
-
 }
-

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppInfoDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppInfoDomainResponse.php
@@ -1,23 +1,20 @@
 <?php
-namespace Metaregistrar\EPP;
 
-use phpseclib3\Math\BigInteger\Engines\PHP;
+namespace Metaregistrar\EPP;
 
 /**
  * Class dnsbeEppInfoDomainResponse
  * @package Metaregistrar\EPP
  */
-class dnsbeEppInfoDomainResponse extends eppInfoDomainResponse {
-    function __construct() {
-        parent::__construct();
-    }
-
+class dnsbeEppInfoDomainResponse extends eppInfoDomainResponse
+{
 
     /**
      * Retrieve a boolean flag if this domain name is in quarantine or not
      * @return bool|null
      */
-    public function getQuarantined() {
+    public function getQuarantined()
+    {
         $xpath = $this->xPath();
         $result = $xpath->query('/epp:epp/epp:response/epp:extension/dnsbe:ext/dnsbe:infData/dnsbe:domain/dnsbe:quarantined');
         if ($result->length > 0) {
@@ -36,7 +33,8 @@ class dnsbeEppInfoDomainResponse extends eppInfoDomainResponse {
      * Retrieve a boolean flag if this domain name is on hold or not
      * @return bool|null
      */
-    public function getOnHold() {
+    public function getOnHold()
+    {
         $xpath = $this->xPath();
         $result = $xpath->query('/epp:epp/epp:response/epp:extension/dnsbe:ext/dnsbe:infData/dnsbe:domain/dnsbe:onhold');
         if ($result->length > 0) {
@@ -53,7 +51,8 @@ class dnsbeEppInfoDomainResponse extends eppInfoDomainResponse {
     /**
      * @return null|string
      */
-    public function getDomainDeletionDate() {
+    public function getDomainDeletionDate()
+    {
         $xpath = $this->xPath();
         $result = $xpath->query('/epp:epp/epp:response/epp:extension/dnsbe:ext/dnsbe:infData/dnsbe:domain/dnsbe:deletionDate');
         if ($result->length > 0) {
@@ -67,15 +66,16 @@ class dnsbeEppInfoDomainResponse extends eppInfoDomainResponse {
      * Retrieve a string with the nameserver group
      * @return null|array
      */
-    public function getNameserverGroup() {
+    public function getNameserverGroup()
+    {
         $xpath = $this->xPath();
         $result = $xpath->query('/epp:epp/epp:response/epp:extension/dnsbe:ext/dnsbe:infData/dnsbe:domain/dnsbe:nsgroup');
         if ($result->length > 0) {
-           $arr = [];
-           foreach ($result as $item){
-              $arr[]=$item->nodeValue;
-           }
-           return $arr;
+            $arr = [];
+            foreach ($result as $item) {
+                $arr[] = $item->nodeValue;
+            }
+            return $arr;
         } else {
             return null;
         }
@@ -98,9 +98,8 @@ class dnsbeEppInfoDomainResponse extends eppInfoDomainResponse {
             return false;
         }
 
-        $reason = $result->item(0)?->attributes?->item(0)?->value;
+        $reason = $result->item(0)?->attributes?->item(0)?->nodeValue;
 
         return $nameserversOveridden === 'true' && $reason === 'Pending registrant verification';
     }
 }
-

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppReactivateDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppReactivateDomainResponse.php
@@ -1,8 +1,5 @@
 <?php
-namespace Metaregistrar\EPP;
-class dnsbeEppReactivateDomainResponse extends eppResponse {
-    function __construct() {
-        parent::__construct();
-    }
 
-}
+namespace Metaregistrar\EPP;
+
+class dnsbeEppReactivateDomainResponse extends eppResponse {}

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppTransferResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppTransferResponse.php
@@ -1,49 +1,21 @@
 <?php
+
 namespace Metaregistrar\EPP;
 
-/*
-<?xml version="1.0" encoding="UTF-8"?>
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:dnsbe="http://www.dns.be/xml/epp/dnsbe-1.0">
-  <response>
-    <result code="2306">
-      <msg>Parameter value policy error</msg>
-    </result>
-    <extension>
-      <dnsbe:ext>
-        <dnsbe:result>
-          <dnsbe:msg>authorisation code is invalid</dnsbe:msg>
-        </dnsbe:result>
-      </dnsbe:ext>
-    </extension>
-    <trID>
-      <clTRID>5a01a56857e45</clTRID>
-      <svTRID>dnsbe-78621920</svTRID>
-    </trID>
-  </response>
-</epp>
- */
-
-
-
-class dnsbeEppTransferResponse extends eppTransferResponse {
-
-    function __construct() {
-        parent::__construct();
+class dnsbeEppTransferResponse extends eppTransferResponse
+{
+  /**
+   *
+   * @return string
+   */
+  public function getMsg()
+  {
+    $xpath = $this->xPath();
+    $result = $xpath->query('/epp:epp/epp:response/epp:extension/dnsbe:ext/dnsbe:result/dnsbe:msg');
+    if ($result->length > 0) {
+      return $result->item(0)->nodeValue;
+    } else {
+      return null;
     }
-
-    /**
-     *
-     * @return string
-     */
-    public function getMsg() {
-        $xpath = $this->xPath();
-        $result = $xpath->query('/epp:epp/epp:response/epp:extension/dnsbe:ext/dnsbe:result/dnsbe:msg');
-        if ($result->length > 0) {
-            return $result->item(0)->nodeValue;
-        } else {
-            return null;
-        }
-    }
-
+  }
 }
-

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppUndeleteDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppUndeleteDomainResponse.php
@@ -1,8 +1,5 @@
 <?php
-namespace Metaregistrar\EPP;
-class dnsbeEppUndeleteDomainResponse extends eppResponse {
-    function __construct() {
-        parent::__construct();
-    }
 
-}
+namespace Metaregistrar\EPP;
+
+class dnsbeEppUndeleteDomainResponse extends eppResponse {}

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppUpdateContactResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppUpdateContactResponse.php
@@ -1,14 +1,5 @@
 <?php
+
 namespace Metaregistrar\EPP;
 
-class dnsbeEppUpdateContactResponse extends eppUpdateContactResponse {
-    function __construct() {
-        parent::__construct();
-    }
-	
-    function __destruct() {
-        parent::__destruct();
-    }
-
-}
-
+class dnsbeEppUpdateContactResponse extends eppUpdateContactResponse {}

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppUpdateDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppUpdateDomainResponse.php
@@ -2,6 +2,4 @@
 
 namespace Metaregistrar\EPP;
 
-class dnsbeEppUpdateDomainResponse extends eppUpdateDomainResponse {
-
-}
+class dnsbeEppUpdateDomainResponse extends eppUpdateDomainResponse {}


### PR DESCRIPTION
Like #434, this PR removes the call to the extended class constructor for all DnsBe response classes.