### PR TITLE
Initialize eppResponse with eppRequest in constructor

### DIFF
--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppExceptions/dnsbeEppException.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppExceptions/dnsbeEppException.php
@@ -37,7 +37,7 @@ class dnsbeEppException extends eppException
     public function __construct($message = '', $code = 0, ?Exception $previous = null, $reason = null, $command = null)
     {
         if ($command) {
-            $this->eppresponse = new eppResponse();
+            $this->eppresponse = new eppResponse(new eppRequest());
             $this->eppresponse->loadXML($command);
         }
         parent::__construct($message, $code, $previous, $reason, $command);


### PR DESCRIPTION
dnsbeEppException uses the eppResponse constructor, which requires eppRequest as a parameter.

This PR resolves the error. There's probably a better way to handle it, but I haven't found one.