### PR TITLE
PHP 8.5 deprecation fix

### DIFF
--- a/Protocols/EPP/eppData/eppIDNA.php
+++ b/Protocols/EPP/eppData/eppIDNA.php
@@ -929,7 +929,7 @@ class eppIDNA {
         if (self::$_mb_string_overload) {
             return mb_strlen($string, '8bit');
         }
-        return strlen((binary)$string);
+        return strlen((string)$string);
     }
 
     /**


### PR DESCRIPTION
Non-canonical cast (binary) is deprecated, use the (string) cast instead.