### PR TITLE
Add getAdditionalInfo method to dnsbeEppCheckDomainResponse

### DIFF
--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppCheckDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppCheckDomainResponse.php
@@ -2,4 +2,52 @@
 
 namespace Metaregistrar\EPP;
 
-class dnsbeEppCheckDomainResponse extends eppCheckDomainResponse {}
+class dnsbeEppCheckDomainResponse extends eppCheckDomainResponse {
+    function __construct() {
+        parent::__construct();
+    }
+
+    public function getAdditionalInfo() {
+        $xpath = $this->xPath();
+        $nodes = $xpath->query('//dnsbe:cd[dnsbe:availableDate or dnsbe:status]');
+
+        $result = [];
+
+        foreach ($nodes as $node) {
+            $nameNodes = $xpath->query('dnsbe:name', $node);
+            if ($nameNodes === false || $nameNodes->length === 0) {
+                continue;
+            }
+
+            $item = [
+                'domain' => trim($nameNodes->item(0)->textContent),
+            ];
+
+            $dateNodes = $xpath->query('dnsbe:availableDate', $node);
+            if ($dateNodes !== false && $dateNodes->length > 0) {
+                $item['availableDate'] = trim($dateNodes->item(0)->textContent);
+            }
+
+            $statusNodes = $xpath->query('dnsbe:status', $node);
+            if ($statusNodes !== false && $statusNodes->length > 0) {
+                $statuses = [];
+                foreach ($statusNodes as $statusNode) {
+                    if ($statusNode instanceof DOMElement) {
+                        $status = $statusNode->getAttribute('s');
+                        if ($status !== '') {
+                            $statuses[] = $status;
+                        }
+                    }
+                }
+
+                if (!empty($statuses)) {
+                    $item['status'] = $statuses;
+                }
+
+            }
+
+            $result[] = $item;
+        }
+        return $result;
+    }
+}

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppCheckDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppCheckDomainResponse.php
@@ -3,10 +3,6 @@
 namespace Metaregistrar\EPP;
 
 class dnsbeEppCheckDomainResponse extends eppCheckDomainResponse {
-    function __construct() {
-        parent::__construct();
-    }
-
     public function getAdditionalInfo() {
         $xpath = $this->xPath();
         $nodes = $xpath->query('//dnsbe:cd[dnsbe:availableDate or dnsbe:status]');


### PR DESCRIPTION
Retrieve the extra information from the dns.be checkdomain response:
- AvailableDate when the domain is in quarataine
- Status when the domain is not available / registered