### PR TITLE
Add support for EURid nameserver groups (NS Groups)

### DIFF
--- a/Protocols/EPP/eppExtensions/domain-ext-2.5/eppRequests/euridEppUpdateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/domain-ext-2.5/eppRequests/euridEppUpdateDomainRequest.php
@@ -31,7 +31,7 @@ use DOMElement;
             </domain:update>
         </update>
         <extension>
-            <domain-ext:update xmlns:domain-ext="http://www.eurid.eu/xml/epp/domain-ext-2.6">
+            <domain-ext:update xmlns:domain-ext="http://www.eurid.eu/xml/epp/domain-ext-2.5">
                 <domain-ext:add>
                     <domain-ext:nsgroup>nsgroup-1573042729356</domain-ext:nsgroup>
                 </domain-ext:add>

--- a/Protocols/EPP/eppExtensions/domain-ext-2.5/eppRequests/euridEppUpdateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/domain-ext-2.5/eppRequests/euridEppUpdateDomainRequest.php
@@ -6,13 +6,10 @@ use DOMElement;
 
 /*
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<epp
-    xmlns="urn:ietf:params:xml:ns:epp-1.0"
-    xmlns:eurid="http://www.eurid.eu/xml/epp/eurid-1.0">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:eurid="http://www.eurid.eu/xml/epp/eurid-1.0">
     <command>
         <update>
-            <domain:update
-                xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+            <domain:update xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
                 <domain:name>somedomain</domain:name>
                 <domain:add>
                     <domain:ns>
@@ -34,8 +31,7 @@ use DOMElement;
             </domain:update>
         </update>
         <extension>
-            <domain-ext:update
-                xmlns:domain-ext="http://www.eurid.eu/xml/epp/domain-ext-2.5">
+            <domain-ext:update xmlns:domain-ext="http://www.eurid.eu/xml/epp/domain-ext-2.6">
                 <domain-ext:add>
                     <domain-ext:nsgroup>nsgroup-1573042729356</domain-ext:nsgroup>
                 </domain-ext:add>

--- a/Protocols/EPP/eppExtensions/domain-ext-2.5/eppRequests/euridEppUpdateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/domain-ext-2.5/eppRequests/euridEppUpdateDomainRequest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Metaregistrar\EPP;
+
+class euridEppUpdateDomainRequest extends eppUpdateDomainRequest
+{
+    public function __construct(
+        $objectname,
+        $addinfo = null,
+        $removeinfo = null,
+        $updateinfo = null,
+        $forcehostattr = true,
+        $namespacesinroot = true,
+        $addnsgroup = null,
+        $removensgroup = null
+    ) {
+        parent::__construct($objectname, $addinfo, $removeinfo, $updateinfo, $forcehostattr, $namespacesinroot);
+        $this->updatensgroup($addnsgroup, $removensgroup);
+    }
+
+    public function updatensgroup($addnsgroup = null, $removensgroup = null)
+    {
+        if ($addnsgroup === null && $removensgroup === null) {
+            return;
+        }
+
+        $this->addExtension('xmlns:dnsbe', 'http://www.eurid.eu/xml/epp/domain-ext-2.6');
+        $ext = $this->createElement('extension');
+        $dnsext = $this->createElement('domain-ext');
+        $update = $this->createElement('domain-ext:update');
+        $domain = $this->createElement('domain-ext:rem');
+        if ($addnsgroup !== null) {
+            if (is_array($addnsgroup) && !empty($addnsgroup)) {
+                $add = $this->createElement('domain-ext:add');
+                foreach ($addnsgroup as $nsgroupname) {
+                    $add->appendChild($this->createElement('domain-ext:nsgroup', $nsgroupname));
+                }
+            } elseif (is_string($addnsgroup)) {
+                $add = $this->createElement('domain-ext:add');
+                $add->appendChild($this->createElement('domain-ext:nsgroup', $addnsgroup));
+            } else {
+                throw new eppException("addnsgroup must either be an array or a string in updatensgroup");
+            }
+            $domain->appendChild($add);
+        }
+        if ($removensgroup !== null) {
+            if (is_array($removensgroup) && !empty($removensgroup)) {
+                $rem = $this->createElement('domain-ext:rem');
+                foreach ($removensgroup as $nsgroupname) {
+                    $rem->appendChild($this->createElement('domain-ext:nsgroup', $nsgroupname));
+                }
+            } elseif (is_string($removensgroup)) {
+                $rem = $this->createElement('domain-ext:rem');
+                $rem->appendChild($this->createElement('domain-ext:nsgroup', $removensgroup));
+            } else {
+                throw new eppException("removensgroup must either be an array or a string in updatensgroup");
+            }
+            $domain->appendChild($rem);
+        }
+        $update->appendChild($domain);
+        $dnsext->appendChild($update);
+        $ext->appendChild($dnsext);
+        $this->getCommand()->appendChild($ext);
+        $this->addSessionId();
+    }
+
+}

--- a/Protocols/EPP/eppExtensions/domain-ext-2.5/eppRequests/euridEppUpdateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/domain-ext-2.5/eppRequests/euridEppUpdateDomainRequest.php
@@ -59,7 +59,7 @@ class euridEppUpdateDomainRequest extends eppUpdateDomainRequest
         parent::addSessionId();
     }
 
-    public function updateNameserverGroups(string|array|null $addnsgroup = null, string|array|null $removensgroup = null): void
+    private function updateNameserverGroups(string|array|null $addnsgroup = null, string|array|null $removensgroup = null): void
     {
         if ($addnsgroup === null && $removensgroup === null) {
             return;

--- a/Protocols/EPP/eppExtensions/domain-ext-2.5/eppRequests/euridEppUpdateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/domain-ext-2.5/eppRequests/euridEppUpdateDomainRequest.php
@@ -4,6 +4,47 @@ namespace Metaregistrar\EPP;
 
 use DOMElement;
 
+/*
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<epp
+    xmlns="urn:ietf:params:xml:ns:epp-1.0"
+    xmlns:eurid="http://www.eurid.eu/xml/epp/eurid-1.0">
+    <command>
+        <update>
+            <domain:update
+                xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+                <domain:name>somedomain</domain:name>
+                <domain:add>
+                    <domain:ns>
+                        <domain:hostAttr>
+                            <domain:hostName>ns1.abc.eu</domain:hostName>
+                        </domain:hostAttr>
+                        <domain:hostAttr>
+                            <domain:hostName>ns2.somedomain.eu</domain:hostName>
+                            <domain:hostAddr ip="v4">178.32.172.146</domain:hostAddr>
+                        </domain:hostAttr>
+                        <domain:hostAttr>
+                            <domain:hostName>ns3.somedomain.eu</domain:hostName>
+                            <domain:hostAddr ip="v6">2001:67c:9c:1::184</domain:hostAddr>
+                        </domain:hostAttr>
+                    </domain:ns>
+                    <domain:contact type="tech">c320</domain:contact>
+                    <domain:contact type="tech">c321</domain:contact>
+                </domain:add>
+            </domain:update>
+        </update>
+        <extension>
+            <domain-ext:update
+                xmlns:domain-ext="http://www.eurid.eu/xml/epp/domain-ext-2.5">
+                <domain-ext:add>
+                    <domain-ext:nsgroup>nsgroup-1573042729356</domain-ext:nsgroup>
+                </domain-ext:add>
+            </domain-ext:update>
+        </extension>
+        <clTRID>domain-update02</clTRID>
+    </command>
+</epp>
+*/
 class euridEppUpdateDomainRequest extends eppUpdateDomainRequest
 {
     public function __construct(
@@ -13,36 +54,36 @@ class euridEppUpdateDomainRequest extends eppUpdateDomainRequest
         ?eppDomain $updateinfo = null,
         bool $forcehostattr = true,
         bool $namespacesinroot = true,
+        bool $usecdata = true,
         string|array|null $addnsgroup = null,
         string|array|null $removensgroup = null
     ) {
-        parent::__construct($objectname, $addinfo, $removeinfo, $updateinfo, $forcehostattr, $namespacesinroot);
-        $this->updatensgroup($addnsgroup, $removensgroup);
+        parent::__construct($objectname, $addinfo, $removeinfo, $updateinfo, $forcehostattr, $namespacesinroot, $usecdata);
+        $this->updateNameserverGroups($addnsgroup, $removensgroup);
         parent::addSessionId();
     }
 
-    public function updatensgroup(string|array|null $addnsgroup = null, string|array|null $removensgroup = null): void
+    public function updateNameserverGroups(string|array|null $addnsgroup = null, string|array|null $removensgroup = null): void
     {
         if ($addnsgroup === null && $removensgroup === null) {
             return;
         }
 
-        $create = $this->createElement('domain-ext:update');
-        $this->setNamespace('xmlns:domain', 'urn:ietf:params:xml:ns:domain-1.0', $create);
-        $this->setNamespace('xmlns:domain-ext', 'http://www.eurid.eu/xml/epp/domain-ext-2.5', $create);
+        $update = $this->createElement('domain-ext:update');
+        $update->setAttribute('xmlns:domain-ext', 'http://www.eurid.eu/xml/epp/domain-ext-2.5');
 
         if ($addnsgroup !== null) {
-            $this->processNsgroup($create, 'domain-ext:add', $addnsgroup);
+            $this->processNameservergroup($update, 'domain-ext:add', $addnsgroup);
         }
 
         if ($removensgroup !== null) {
-            $this->processNsgroup($create, 'domain-ext:rem', $removensgroup);
+            $this->processNameservergroup($update, 'domain-ext:rem', $removensgroup);
         }
 
-        $this->getExtension()->appendChild($create);
+        $this->getExtension()->appendChild($update);
     }
 
-    private function processNsgroup(DOMElement $parent, string $action, string|array $nsgroup): void
+    private function processNameservergroup(DOMElement $parent, string $action, string|array $nsgroup): void
     {
         if (is_array($nsgroup) && !empty($nsgroup)) {
             $element = $this->createElement($action);

--- a/Protocols/EPP/eppExtensions/domain-ext-2.5/eppResponses/euridEppInfoDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/domain-ext-2.5/eppResponses/euridEppInfoDomainResponse.php
@@ -163,4 +163,23 @@ class euridEppInfoDomainResponse extends eppInfoDomainResponse {
         }
         return $cont;
     }
+
+    /**
+     * Retrieve the names for the nameserver groups
+     * @return null|array
+     */
+    public function getNameserverGroups()
+    {
+        $xpath = $this->xPath();
+        $result = $xpath->query('/epp:epp/epp:response/epp:extension/domain-ext:infData/domain-ext:nsgroup');
+        if ($result->length > 0) {
+            $arr = [];
+            foreach ($result as $item) {
+                $arr[] = $item->nodeValue;
+            }
+            return $arr;
+        } else {
+            return null;
+        }
+    }
 }

--- a/Protocols/EPP/eppExtensions/domain-ext-2.5/eppResponses/euridEppInfoDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/domain-ext-2.5/eppResponses/euridEppInfoDomainResponse.php
@@ -165,21 +165,23 @@ class euridEppInfoDomainResponse extends eppInfoDomainResponse {
     }
 
     /**
-     * Retrieve the names for the nameserver groups
-     * @return null|array
+     * Retrieve the names for the nameserver groups.
+     *
+     * @return array|null
      */
     public function getNameserverGroups()
     {
         $xpath = $this->xPath();
-        $result = $xpath->query('/epp:epp/epp:response/epp:extension/domain-ext:infData/domain-ext:nsgroup');
-        if ($result->length > 0) {
+        $result = @$xpath->query('/epp:epp/epp:response/epp:extension/domain-ext:infData/domain-ext:nsgroup');
+        if (is_object($result) && $result->length > 0) {
             $arr = [];
             foreach ($result as $item) {
                 $arr[] = $item->nodeValue;
             }
+
             return $arr;
-        } else {
-            return null;
         }
+
+        return null;
     }
 }

--- a/Protocols/EPP/eppExtensions/domain-ext-2.5/includes.php
+++ b/Protocols/EPP/eppExtensions/domain-ext-2.5/includes.php
@@ -15,3 +15,6 @@ $this->addCommandResponse('Metaregistrar\EPP\euridEppUndeleteDomainRequest', 'Me
 
 include_once(dirname(__FILE__) . '/eppResponses/euridEppInfoDomainResponse.php');
 $this->addCommandResponse('Metaregistrar\EPP\eppInfoDomainRequest', 'Metaregistrar\EPP\euridEppInfoDomainResponse');
+
+include_once(dirname(__FILE__) . '/eppRequests/euridEppUpdateDomainRequest.php');
+$this->addCommandResponse('Metaregistrar\EPP\euridEppUpdateDomainRequest', 'Metaregistrar\EPP\eppUpdateDomainResponse');

--- a/Protocols/EPP/eppExtensions/nsgroup-1.1/eppRequests/euridEppInfoNsgroupRequest.php
+++ b/Protocols/EPP/eppExtensions/nsgroup-1.1/eppRequests/euridEppInfoNsgroupRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Metaregistrar\EPP;
+
+/*
+<?xml version="1.0" encoding="UTF-8"?>
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+    <command>
+        <info>
+            <nsgroup:info>
+                <nsgroup:name>test</nsgroup:name>
+            </nsgroup:info>
+        </info>
+        <clTRID>nsgroup-test-456</clTRID>
+    </command>
+</epp>
+*/
+class euridEppInfoNsgroupRequest extends eppRequest
+{
+    /**
+     * @var \DOMElement
+     */
+    private $hostobject;
+
+    /**
+     * euridEppInfoNsgroupRequest constructor.
+     * @param $nsgroup
+     * @throws eppException
+     */
+    public function __construct($nsgroup)
+    {
+        parent::__construct();
+        $this->addExtension('xmlns:nsgroup', 'http://www.eurid.eu/xml/epp/nsgroup-1.1');
+        if (is_string($nsgroup)) {
+            if (strlen($nsgroup) > 0) {
+                $this->addNsGroup($nsgroup);
+            } else {
+                throw new eppException("Domain name length may not be 0 on euridEppInfoNsgroupRequest");
+            }
+        } else {
+            throw new eppException("Domain name must be string on euridEppInfoNsgroupRequest");
+        }
+        $this->addSessionId();
+    }
+
+    /**
+     * @param $groupname
+     */
+    private function addNsGroup($groupname)
+    {
+        $create = $this->createElement('info');
+        $this->hostobject = $this->createElement('nsgroup:info');
+        $this->hostobject->appendChild($this->createElement('nsgroup:name', $groupname));
+        $create->appendChild($this->hostobject);
+        $this->getCommand()->appendChild($create);
+    }
+}

--- a/Protocols/EPP/eppExtensions/nsgroup-1.1/eppResponses/euridEppInfoNsgroupResponse.php
+++ b/Protocols/EPP/eppExtensions/nsgroup-1.1/eppResponses/euridEppInfoNsgroupResponse.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Metaregistrar\EPP;
+
+/**
+ * Class euridEppInfoNsgroupResponse
+ * @package Metaregistrar\EPP
+ */
+class euridEppInfoNsgroupResponse extends eppResponse
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     *
+     * @return string
+     */
+    public function getNsgroupName()
+    {
+        $xpath = $this->xPath();
+        $result = $xpath->query('/epp:epp/epp:response/epp:resData/nsgroup:infData/nsgroup:name');
+        if ($result->length > 0) {
+            return $result->item(0)->nodeValue;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function getNsgroupHosts()
+    {
+        $return = [];
+        $xpath = $this->xPath();
+        $result = $xpath->query('/epp:epp/epp:response/epp:resData/nsgroup:infData/nsgroup:ns');
+        if ($result->length > 0) {
+            foreach ($result as $item) {
+                $return[] = $item->nodeValue;
+            }
+        }
+        return $return;
+    }
+}

--- a/Protocols/EPP/eppExtensions/nsgroup-1.1/eppResponses/euridEppInfoNsgroupResponse.php
+++ b/Protocols/EPP/eppExtensions/nsgroup-1.1/eppResponses/euridEppInfoNsgroupResponse.php
@@ -31,11 +31,6 @@ namespace Metaregistrar\EPP;
  */
 class euridEppInfoNsgroupResponse extends eppResponse
 {
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
     /**
      *
      * @return string

--- a/Protocols/EPP/eppExtensions/nsgroup-1.1/eppResponses/euridEppInfoNsgroupResponse.php
+++ b/Protocols/EPP/eppExtensions/nsgroup-1.1/eppResponses/euridEppInfoNsgroupResponse.php
@@ -2,6 +2,29 @@
 
 namespace Metaregistrar\EPP;
 
+/*
+<?xml version="1.0" encoding="UTF-8"?>
+<epp
+    xmlns="urn:ietf:params:xml:ns:epp-1.0"
+    xmlns:nsgroup="http://www.eurid.eu/xml/epp/nsgroup-1.1">
+    <response>
+        <result code="1000">
+            <msg>Command completed successfully</msg>
+        </result>
+        <resData>
+            <nsgroup:infData>
+                <nsgroup:name>test1</nsgroup:name>
+                <nsgroup:ns>ns2.example.com</nsgroup:ns>
+                <nsgroup:ns>ns1.example.com</nsgroup:ns>
+            </nsgroup:infData>
+        </resData>
+        <trID>
+            <clTRID>6836ef66e5d2a</clTRID>
+            <svTRID>ef986e968-ebf7-479d-9822-ad8ebd47075d</svTRID>
+        </trID>
+    </response>
+</epp>
+*/
 /**
  * Class euridEppInfoNsgroupResponse
  * @package Metaregistrar\EPP

--- a/Protocols/EPP/eppExtensions/nsgroup-1.1/includes.php
+++ b/Protocols/EPP/eppExtensions/nsgroup-1.1/includes.php
@@ -1,0 +1,8 @@
+<?php
+
+$this->addExtension('nsgroup', 'http://www.eurid.eu/xml/epp/nsgroup-1.1');
+
+include_once(dirname(__FILE__) . '/eppRequests/euridEppInfoNsgroupRequest.php');
+include_once(dirname(__FILE__) . '/eppResponses/euridEppInfoNsgroupResponse.php');
+
+$this->addCommandResponse('Metaregistrar\EPP\euridEppInfoNsgroupRequest', 'Metaregistrar\EPP\euridEppInfoNsgroupResponse');

--- a/Protocols/EPP/eppExtensions/nsgroup-1.1/includes.php
+++ b/Protocols/EPP/eppExtensions/nsgroup-1.1/includes.php
@@ -1,7 +1,5 @@
 <?php
 
-$this->addExtension('nsgroup', 'http://www.eurid.eu/xml/epp/nsgroup-1.1');
-
 include_once(dirname(__FILE__) . '/eppRequests/euridEppInfoNsgroupRequest.php');
 include_once(dirname(__FILE__) . '/eppResponses/euridEppInfoNsgroupResponse.php');
 

--- a/Registries/euridEppConnection/eppConnection.php
+++ b/Registries/euridEppConnection/eppConnection.php
@@ -20,6 +20,7 @@ class euridEppConnection extends eppConnection {
         parent::useExtension('contact-ext-1.3');
         parent::useExtension('registrarFinance-1.0');
         parent::useExtension('poll-1.2');
+        parent::useExtension('nsgroup-1.1');
 
         /* parse the eurid extensions */
         parent::addCommandResponse('Metaregistrar\EPP\eppInfoContactRequest', 'Metaregistrar\EPP\euridEppInfoContactResponse');

--- a/Registries/euridEppConnection/eppConnection.php
+++ b/Registries/euridEppConnection/eppConnection.php
@@ -7,7 +7,14 @@ class euridEppConnection extends eppConnection {
         parent::__construct($logging, $settingsfile);
 
         parent::enableDnssec();
-        parent::setServices(array('urn:ietf:params:xml:ns:domain-1.0' => 'domain', 'urn:ietf:params:xml:ns:contact-1.0' => 'contact','http://www.eurid.eu/xml/epp/registrarFinance-1.0'=>'registrar'));
+        parent::setServices(
+            [
+                'urn:ietf:params:xml:ns:domain-1.0' => 'domain',
+                'urn:ietf:params:xml:ns:contact-1.0' => 'contact',
+                'http://www.eurid.eu/xml/epp/registrarFinance-1.0' => 'registrar',
+                'http://www.eurid.eu/xml/epp/nsgroup-1.1' => 'nsgroup',
+            ]
+        );
         parent::useExtension('authInfo-1.1');
         parent::useExtension('domain-ext-2.5');
         parent::useExtension('contact-ext-1.3');


### PR DESCRIPTION
## What does it do?

This PR adds support for `EURid` nameserver groups (NS Groups) by introducing new request and response classes and extending the domain info response.

### Changes

1. Added `euridEppUpdateDomainRequest`, which supports adding and removing nameserver groups from a domain.
2. Added `getNameserverGroups()` to `euridEppInfoDomainResponse`, allowing retrieval of the nameserver groups associated with a domain.
3. Added `euridEppInfoNsgroupRequest` and `euridEppInfoNsgroupResponse`, which provide the ability to retrieve detailed information about a nameserver group.

## How to test

### Domain Update

1. Create an `euridEppUpdateDomainRequest`.
2. Add and/or remove one or more nameserver groups.
3. Submit the request and verify that the domain's nameserver group assignments are updated successfully.

### Domain Info

1. Retrieve a domain using `euridEppInfoDomainRequest`.
2. Call `getNameserverGroups()` on the resulting `euridEppInfoDomainResponse`.
3. Verify that the returned nameserver groups match the domain's configuration.

### Nameserver Group Info

1. Create and submit an `euridEppInfoNsgroupRequest`.
2. Verify that an `euridEppInfoNsgroupResponse` is returned.
3. Confirm that the response contains the expected information for the requested nameserver group.
