### PR TITLE
Add `dnsbeEppPollResponse` implementation

### DIFF
--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppPollResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppPollResponse.php
@@ -9,22 +9,22 @@ class dnsbeEppPollResponse extends eppPollResponse
         parent::__construct();
     }
 
-    public function getPollResAction()
+    public function getAction()
     {
         return $this->queryPath('/epp:epp/epp:response/epp:resData/dnsbe:pollRes/dnsbe:action');
     }
 
-    public function getPollResDomainname()
+    public function getDomainname()
     {
         return $this->queryPath('/epp:epp/epp:response/epp:resData/dnsbe:pollRes/dnsbe:domainname');
     }
 
-    public function getPollResReturncode()
+    public function getReturncode()
     {
         return $this->queryPath('/epp:epp/epp:response/epp:resData/dnsbe:pollRes/dnsbe:returncode');
     }
 
-    public function getPollResType()
+    public function getType()
     {
         return $this->queryPath('/epp:epp/epp:response/epp:resData/dnsbe:pollRes/dnsbe:type');
     }

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppPollResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppPollResponse.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Metaregistrar\EPP;
+
+class dnsbeEppPollResponse extends eppPollResponse
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function getPollResAction()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/dnsbe:pollRes/dnsbe:action');
+    }
+
+    public function getPollResDomainname()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/dnsbe:pollRes/dnsbe:domainname');
+    }
+
+    public function getPollResReturncode()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/dnsbe:pollRes/dnsbe:returncode');
+    }
+
+    public function getPollResType()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/dnsbe:pollRes/dnsbe:type');
+    }
+
+    public function getContact()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/dnsbe:pollRes/dnsbe:contact');
+    }
+
+}

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/includes.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/includes.php
@@ -55,3 +55,6 @@ $this->addCommandResponse('Metaregistrar\EPP\dnsbeEppUpdateDomainRequest', 'Meta
 
 include_once(dirname(__FILE__) . '/eppExceptions/dnsbeEppException.php');
 $this->addException('Metaregistrar\EPP\dnsbeEppException');
+
+include_once(dirname(__FILE__) . '/eppResponses/dnsbeEppPollResponse.php');
+$this->addCommandResponse('Metaregistrar\EPP\eppPollRequest', 'Metaregistrar\EPP\dnsbeEppPollResponse');


### PR DESCRIPTION
## What does it do?
Implements `dnsbeEppPollResponse`, which can be used to extract DNS Belgium specific information from EPP poll responses.

## How to test

1. Generate or retrieve a DNS Belgium EPP poll message.
2. Verify that the poll response is parsed as a `dnsbeEppPollResponse`.
3. Confirm that DNS Belgium specific information can be successfully extracted from the response.