### PR TITLE
Add `sidnEppInfoContactResponse` implementation

### DIFF
--- a/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/eppResponses/sidnEppInfoContactResponse.php
+++ b/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/eppResponses/sidnEppInfoContactResponse.php
@@ -6,8 +6,6 @@ class sidnEppInfoContactResponse extends eppInfoContactResponse
 {
     public function getLegalForm()
     {
-        $xpath = $this->xPath();
-        $result = $xpath->query('/epp:epp/epp:response/epp:extension/sidn-ext-epp:ext/sidn-ext-epp:infData/sidn-ext-epp:contact/sidn-ext-epp:legalForm');
-        return $result->item(0)->nodeValue;
+        return $this->queryPath('/epp:epp/epp:response/epp:extension/sidn-ext-epp:ext/sidn-ext-epp:infData/sidn-ext-epp:contact/sidn-ext-epp:legalForm');
     }
 }

--- a/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/eppResponses/sidnEppInfoContactResponse.php
+++ b/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/eppResponses/sidnEppInfoContactResponse.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Metaregistrar\EPP;
+
+class sidnEppInfoContactResponse extends eppInfoContactResponse
+{
+    public function getLegalForm()
+    {
+        $xpath = $this->xPath();
+        $result = $xpath->query('/epp:epp/epp:response/epp:extension/sidn-ext-epp:ext/sidn-ext-epp:infData/sidn-ext-epp:contact/sidn-ext-epp:legalForm');
+        return $result->item(0)->nodeValue;
+    }
+}

--- a/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/includes.php
+++ b/Protocols/EPP/eppExtensions/sidn-ext-epp-1.0/includes.php
@@ -35,3 +35,6 @@ $this->addCommandResponse('Metaregistrar\EPP\sidnEppUpdateDomainRequest', 'Metar
 
 include_once(dirname(__FILE__) . '/eppExceptions/sidnEppException.php');
 $this->addException('Metaregistrar\EPP\sidnEppException');
+
+include_once(dirname(__FILE__) . '/eppResponses/sidnEppInfoContactResponse.php');
+$this->addCommandResponse('Metaregistrar\EPP\eppInfoContactRequest', 'Metaregistrar\EPP\sidnEppInfoContactResponse');


### PR DESCRIPTION
## What does it do?
Implements `sidnEppInfoContactResponse`, which provides access to SIDN specific information returned in EPP contact info responses.

## How to test
1. Execute an `eppInfoContactRequest` for a domain using the `sidnEppConnection`.
2. Verify that the response is returned as a `sidnEppInfoContactResponse`.
3. Confirm that SIDN specific information can be successfully extracted from the response.
