### PR TITLE
dnssec verisign

### DIFF
--- a/Protocols/EPP/eppExtensions/verisign/eppRequests/verisignEppDnssecUpdateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/verisign/eppRequests/verisignEppDnssecUpdateDomainRequest.php
@@ -1,0 +1,22 @@
+<?php
+namespace Metaregistrar\EPP;
+
+class verisignEppDnssecUpdateDomainRequest extends eppDnssecUpdateDomainRequest {
+    use verisignEppExtension;
+    /**
+     * verisignEppUpdateDomainRequest constructor.
+     *
+     * @param eppDomain $domain
+     * @param null      $add
+     * @param null      $remove
+     * @param null      $update
+     * @throws eppException
+     */
+    public function __construct(eppDomain $domain, $add=null, $remove=null, $update=null) {
+        parent::__construct($domain, $add, $remove, $update);
+        //add namestore extension
+        $this->addNamestore($domain);
+        $this->addSessionId();
+
+    }
+}

--- a/Protocols/EPP/eppExtensions/verisign/includes.php
+++ b/Protocols/EPP/eppExtensions/verisign/includes.php
@@ -34,6 +34,12 @@ $this->addCommandResponse('Metaregistrar\EPP\verisignEppRenewDomainRequest', 'Me
 include_once(dirname(__FILE__) . '/eppRequests/verisignEppUpdateDomainRequest.php');
 $this->addCommandResponse('Metaregistrar\EPP\verisignEppUpdateDomainRequest', 'Metaregistrar\EPP\eppUpdateDomainResponse');
 
+include_once(dirname(__FILE__) . '/eppRequests/verisignEppDnssecUpdateDomainRequest.php');
+$this->addCommandResponse('Metaregistrar\EPP\verisignEppDnssecUpdateDomainRequest', 'Metaregistrar\EPP\eppUpdateDomainResponse');
+
+//include_once(dirname(__FILE__) . '/eppResponses/eppDnssecInfoDomainResponse.php');
+$this->addCommandResponse('Metaregistrar\\EPP\\verisignEppInfoDomainRequest', 'Metaregistrar\\EPP\\eppDnssecInfoDomainResponse');
+
 include_once(dirname(__FILE__) . '/eppRequests/verisignEppRealNameDomainRequest.php');
 $this->addCommandResponse('Metaregistrar\EPP\verisignEppRealNameDomainRequest', 'Metaregistrar\EPP\eppUpdateDomainResponse');
 


### PR DESCRIPTION
Can not change dnssec on verisign and error on get info

Looks like the inheritance option isn't very good
It may be better to connect extensions by modifying requests before sending them using an event handler.

verisignEpp* classes is to huge copy-paste