### PR TITLE
Remove redundant constructors

### DIFF
--- a/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppResponses/atEppPollResponse.php
+++ b/Protocols/EPP/eppExtensions/at-ext-epp-1.0/eppResponses/atEppPollResponse.php
@@ -59,13 +59,6 @@ class atEppPollResponse extends eppPollResponse
     const LOCKTYPE_SPT = "SPT"; # Sperre technische Probleme
     const LOCKTYPE_SKO = "SKO"; # Sperre Konkurs
 
-    /**
-     * atEppPollResponse constructor.
-     */
-    function __construct()
-    {
-        parent::__construct();
-    }
 
     /**
      * @return null|string

--- a/Protocols/EPP/eppExtensions/authInfo-1.1/eppResponses/authEppInfoDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/authInfo-1.1/eppResponses/authEppInfoDomainResponse.php
@@ -2,10 +2,6 @@
 namespace Metaregistrar\EPP;
 
 class authEppInfoDomainResponse extends eppInfoDomainResponse {
-    function __construct() {
-        parent::__construct();
-    }
-
 
     /**
      * Return EURid specific contact type 'onsite', which is not EPP standard

--- a/Protocols/EPP/eppExtensions/balance-1.0/eppResponses/eppBalanceInfoResponse.php
+++ b/Protocols/EPP/eppExtensions/balance-1.0/eppResponses/eppBalanceInfoResponse.php
@@ -14,12 +14,6 @@ namespace Metaregistrar\EPP;
 </balance:infData>
  */
 class eppBalanceInfoResponse extends eppResponse {
-    /**
-     * eppBalanceInfoResponse constructor
-     */
-    function __construct() {
-        parent::__construct();
-    }
 
     /**
      * @return string|null

--- a/Protocols/EPP/eppExtensions/charge-1.0/eppResponses/chargeEppCheckDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/charge-1.0/eppResponses/chargeEppCheckDomainResponse.php
@@ -32,12 +32,6 @@ namespace Metaregistrar\EPP;
 </extension>
  */
 class chargeEppCheckDomainResponse extends eppCheckDomainResponse {
-    /**
-     * chargeEppCheckDomainResponse constructor.
-     */
-    function __construct() {
-        parent::__construct();
-    }
 
     /**
      * Get all charges for all domain names

--- a/Protocols/EPP/eppExtensions/charge-1.0/eppResponses/chargeEppCreateDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/charge-1.0/eppResponses/chargeEppCreateDomainResponse.php
@@ -7,12 +7,6 @@ namespace Metaregistrar\EPP;
 **/
 
 class chargeEppCreateDomainResponse extends eppCreateDomainResponse {
-    /**
-     * chargeEppCreateDomainResponse constructor.
-     */
-    function __construct() {
-        parent::__construct();
-    }
 
     /**
      * Retrieve charges for the created domain name

--- a/Protocols/EPP/eppExtensions/charge-1.0/eppResponses/chargeEppInfoDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/charge-1.0/eppResponses/chargeEppInfoDomainResponse.php
@@ -18,12 +18,6 @@ namespace Metaregistrar\EPP;
 </epp:extension>
  */
 class chargeEppInfoDomainResponse extends eppInfoDomainResponse {
-    /**
-     * chargeEppInfoDomainResponse constructor
-     */
-    function __construct() {
-        parent::__construct();
-    }
 
     /**
      * Get charges for the queried domain name

--- a/Protocols/EPP/eppExtensions/command-ext-1.0/eppResponses/metaregEppInfoContactResponse.php
+++ b/Protocols/EPP/eppExtensions/command-ext-1.0/eppResponses/metaregEppInfoContactResponse.php
@@ -62,15 +62,6 @@ namespace Metaregistrar\EPP;
 class metaregEppInfoContactResponse extends eppInfoContactResponse  {
 
     /**
-     * metaregEppInfoContactResponse constructor.
-     * @param null $originalrequest
-     */
-    public function __construct($originalrequest) {
-        parent::__construct($originalrequest);
-    }
-
-
-    /**
      * @param $registry
      * @param $propertyname
      */

--- a/Protocols/EPP/eppExtensions/cozacontact-1.0/eppResponses/cozaEppBalanceCheckResponse.php
+++ b/Protocols/EPP/eppExtensions/cozacontact-1.0/eppResponses/cozaEppBalanceCheckResponse.php
@@ -39,11 +39,6 @@ namespace Metaregistrar\EPP;
  */
 class cozaEppBalanceCheckResponse extends eppInfoContactResponse {
 
-    function __construct() {
-        parent::__construct();
-    }
-
-
     /**
      * Retrieve an array of domain names associated with this contact
      * @return array|null

--- a/Protocols/EPP/eppExtensions/cozacontact-1.0/eppResponses/cozaEppInfoContactResponse.php
+++ b/Protocols/EPP/eppExtensions/cozacontact-1.0/eppResponses/cozaEppInfoContactResponse.php
@@ -21,11 +21,6 @@ namespace Metaregistrar\EPP;
  */
 class cozaEppInfoContactResponse extends eppInfoContactResponse {
 
-    function __construct() {
-        parent::__construct();
-    }
-
-
     /**
      * Retrieve an array of domain names associated with this contact
      * @return array|null

--- a/Protocols/EPP/eppExtensions/cozadomain-1.0/eppResponses/cozaEppAutorenewResponse.php
+++ b/Protocols/EPP/eppExtensions/cozadomain-1.0/eppResponses/cozaEppAutorenewResponse.php
@@ -26,9 +26,6 @@ namespace Metaregistrar\EPP;
 class cozaEppAutorenewResponse extends eppUpdateDomainResponse
 {
 
-    function __construct() {
-        parent::__construct();
-    }
 
     /**
      * Retrieve the response for the autorenew request

--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppPollResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppPollResponse.php
@@ -4,11 +4,6 @@ namespace Metaregistrar\EPP;
 
 class dnsbeEppPollResponse extends eppPollResponse
 {
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
     public function getAction()
     {
         return $this->queryPath('/epp:epp/epp:response/epp:resData/dnsbe:pollRes/dnsbe:action');
@@ -33,5 +28,4 @@ class dnsbeEppPollResponse extends eppPollResponse
     {
         return $this->queryPath('/epp:epp/epp:response/epp:resData/dnsbe:pollRes/dnsbe:contact');
     }
-
 }

--- a/Protocols/EPP/eppExtensions/fee-0.23/eppResponses/fee0EppCheckDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/fee-0.23/eppResponses/fee0EppCheckDomainResponse.php
@@ -2,9 +2,6 @@
 namespace Metaregistrar\EPP;
 
 class fee0EppCheckdomainResponse extends eppCheckDomainResponse {
-    function __construct() {
-        parent::__construct();
-    }
 
     public function getFees() {
         $xpath = $this->xPath();

--- a/Protocols/EPP/eppExtensions/fee-1.0/eppResponses/feeEppCheckDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/fee-1.0/eppResponses/feeEppCheckDomainResponse.php
@@ -106,9 +106,6 @@ namespace Metaregistrar\EPP;
  * @package Metaregistrar\EPP
  */
 class feeEppCheckDomainResponse extends eppCheckDomainResponse {
-    function __construct() {
-        parent::__construct();
-    }
 
     public function getFees() {
         $xpath = $this->xPath();

--- a/Protocols/EPP/eppExtensions/ficora/eppResponses/ficoraEppCheckBalanceResponse.php
+++ b/Protocols/EPP/eppExtensions/ficora/eppResponses/ficoraEppCheckBalanceResponse.php
@@ -2,9 +2,6 @@
 namespace Metaregistrar\EPP;
 
 class ficoraEppCheckBalanceResponse extends eppResponse {
-    function __construct($originalrequest) {
-        parent::__construct($originalrequest);
-    }
 
     public function getBalanceAmount() {
         $xpath = $this->xPath();

--- a/Protocols/EPP/eppExtensions/finance-1.0/eppResponses/eppFinanceInfoResponse.php
+++ b/Protocols/EPP/eppExtensions/finance-1.0/eppResponses/eppFinanceInfoResponse.php
@@ -14,10 +14,6 @@ namespace Metaregistrar\EPP;
  */
 class eppFinanceInfoResponse extends eppResponse {
 
-    function __construct() {
-        parent::__construct();
-    }
-
     public function getBalance() {
         $xpath = $this->xPath();
         $result = $xpath->query('//finance:balance');

--- a/Protocols/EPP/eppExtensions/iis-1.2/eppResponses/iisEppInfoDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/iis-1.2/eppResponses/iisEppInfoDomainResponse.php
@@ -11,10 +11,6 @@ namespace Metaregistrar\EPP;
  */
 
 class iisEppInfoDomainResponse extends eppInfoDomainResponse {
-    function __construct() {
-        parent::__construct();
-    }
-
 
     /**
      *

--- a/Protocols/EPP/eppExtensions/keysys-1.0/eppResponses/rrpproxyEppInfoContactResponse.php
+++ b/Protocols/EPP/eppExtensions/keysys-1.0/eppResponses/rrpproxyEppInfoContactResponse.php
@@ -13,10 +13,6 @@ namespace Metaregistrar\EPP;
  */
 
 class rrpproxyEppInfoContactResponse extends eppInfoContactResponse {
-    function __construct() {
-        parent::__construct();
-    }
-
 
     /**
      *

--- a/Protocols/EPP/eppExtensions/keysys-1.0/eppResponses/rrpproxyEppInfoDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/keysys-1.0/eppResponses/rrpproxyEppInfoDomainResponse.php
@@ -2,9 +2,6 @@
 namespace Metaregistrar\EPP;
 
 class rrpproxyEppInfoDomainResponse extends eppInfoDomainResponse {
-    function __construct() {
-        parent::__construct();
-    }
 
     /**
      * Get the domain renewal date.

--- a/Protocols/EPP/eppExtensions/nsgroup-1.0/eppResponses/dnsbeEppCreateNsgroupResponse.php
+++ b/Protocols/EPP/eppExtensions/nsgroup-1.0/eppResponses/dnsbeEppCreateNsgroupResponse.php
@@ -1,8 +1,5 @@
 <?php
 namespace Metaregistrar\EPP;
 class dnsbeEppCreateNsgroupResponse extends eppResponse {
-    function __construct() {
-        parent::__construct();
-    }
 
 }

--- a/Protocols/EPP/eppExtensions/nsgroup-1.0/eppResponses/dnsbeEppDeleteNsgroupResponse.php
+++ b/Protocols/EPP/eppExtensions/nsgroup-1.0/eppResponses/dnsbeEppDeleteNsgroupResponse.php
@@ -18,9 +18,6 @@ namespace Metaregistrar\EPP;
  * @package Metaregistrar\EPP
  */
 class dnsbeEppDeleteNsgroupResponse extends eppResponse {
-    function __construct() {
-        parent::__construct();
-    }
    function __destruct() {
       parent::__destruct();
    }

--- a/Protocols/EPP/eppExtensions/nsgroup-1.0/eppResponses/dnsbeEppInfoNsgroupResponse.php
+++ b/Protocols/EPP/eppExtensions/nsgroup-1.0/eppResponses/dnsbeEppInfoNsgroupResponse.php
@@ -1,5 +1,7 @@
 <?php
+
 namespace Metaregistrar\EPP;
+
 /**
 <epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:nsgroup="http://www.dns.be/xml/epp/nsgroup-1.0">
     <response>
@@ -21,16 +23,14 @@ namespace Metaregistrar\EPP;
  * Class dnsbeEppInfoNsgroupResponse
  * @package Metaregistrar\EPP
  */
-class dnsbeEppInfoNsgroupResponse extends eppResponse {
-    function __construct() {
-        parent::__construct();
-    }
-
+class dnsbeEppInfoNsgroupResponse extends eppResponse
+{
     /**
      *
      * @return string
      */
-    public function getNsgroupName() {
+    public function getNsgroupName()
+    {
         $xpath = $this->xPath();
         $result = $xpath->query('/epp:epp/epp:response/epp:resData/nsgroup:infData/nsgroup:name');
         if ($result->length > 0) {
@@ -43,7 +43,8 @@ class dnsbeEppInfoNsgroupResponse extends eppResponse {
     /**
      * @return array
      */
-    public function getNsgroupHosts() {
+    public function getNsgroupHosts()
+    {
         $return = [];
         $xpath = $this->xPath();
         $result = $xpath->query('/epp:epp/epp:response/epp:resData/nsgroup:infData/nsgroup:ns');

--- a/Protocols/EPP/eppExtensions/nsgroup-1.0/eppResponses/dnsbeEppUpdateNsgroupResponse.php
+++ b/Protocols/EPP/eppExtensions/nsgroup-1.0/eppResponses/dnsbeEppUpdateNsgroupResponse.php
@@ -1,8 +1,5 @@
 <?php
 namespace Metaregistrar\EPP;
 class dnsbeEppUpdateNsgroupResponse extends eppResponse {
-    function __construct() {
-        parent::__construct();
-    }
 
 }

--- a/Protocols/EPP/eppExtensions/poll-1.2/eppResponses/euridEppPollResponse.php
+++ b/Protocols/EPP/eppExtensions/poll-1.2/eppResponses/euridEppPollResponse.php
@@ -39,9 +39,6 @@ class euridEppPollResponse extends eppPollResponse{
     const TYPE_NAMESERVERGROUP = "NAMESERVERGROUP";
     const TYPE_PAYMENT = "PAYMENT";
 
-    function __construct() {
-        parent::__construct();
-    }
 
     public function getContext(){
         $xpath = $this->xPath();

--- a/Protocols/EPP/eppExtensions/polldata-1.0/eppResponses/metaregEppPollResponse.php
+++ b/Protocols/EPP/eppExtensions/polldata-1.0/eppResponses/metaregEppPollResponse.php
@@ -2,9 +2,6 @@
 namespace Metaregistrar\EPP;
 
 class metaregEppPollResponse extends eppPollResponse {
-    public function    __construct() {
-        parent::__construct();
-    }
 
     public function getDelDataName() {
         $xpath = $this->xPath();

--- a/Protocols/EPP/eppExtensions/registrar-1.0/eppResponses/dnsbeEppRegistrarInfoResponse.php
+++ b/Protocols/EPP/eppExtensions/registrar-1.0/eppResponses/dnsbeEppRegistrarInfoResponse.php
@@ -7,10 +7,6 @@ namespace Metaregistrar\EPP;
  */
 class dnsbeEppRegistrarInfoResponse extends eppResponse {
 
-    function __construct() {
-        parent::__construct();
-    }
-
     public function getAmountAvailable() {
         $xpath = $this->xPath();
         $result = $xpath->query('//dnsbe:amountAvailable');

--- a/Protocols/EPP/eppExtensions/registrar-1.0/eppResponses/siEppRegistrarInfoResponse.php
+++ b/Protocols/EPP/eppExtensions/registrar-1.0/eppResponses/siEppRegistrarInfoResponse.php
@@ -48,10 +48,6 @@ namespace Metaregistrar\EPP;
  */
 class siEppRegistrarInfoResponse extends eppResponse {
 
-    function __construct() {
-        parent::__construct();
-    }
-
     public function getBalance() {
         $xpath = $this->xPath();
         $result = $xpath->query('//dnssi:balance');

--- a/Protocols/EPP/eppExtensions/registrarFinance-1.0/eppResponses/euridEppRegistrarInfoResponse.php
+++ b/Protocols/EPP/eppExtensions/registrarFinance-1.0/eppResponses/euridEppRegistrarInfoResponse.php
@@ -15,10 +15,6 @@ namespace Metaregistrar\EPP;
  */
 class euridEppRegistrarInfoResponse extends eppResponse {
 
-    function __construct() {
-        parent::__construct();
-    }
-    
     public function getPaymentMode() {
         $xpath = $this->xPath();
         $result = $xpath->query('//registrarFinance:paymentMode');

--- a/Protocols/EPP/eppExtensions/ssl-1.0/eppResponses/metaregSslCreateResponse.php
+++ b/Protocols/EPP/eppExtensions/ssl-1.0/eppResponses/metaregSslCreateResponse.php
@@ -29,10 +29,6 @@ namespace Metaregistrar\EPP;
 
 class metaregSslCreateResponse extends eppResponse  {
 
-    function __construct() {
-        parent::__construct();
-    }
-
     /**
      * @return null|string
      */

--- a/Protocols/EPP/eppExtensions/ssl-1.0/eppResponses/metaregSslDeleteResponse.php
+++ b/Protocols/EPP/eppExtensions/ssl-1.0/eppResponses/metaregSslDeleteResponse.php
@@ -7,7 +7,4 @@ namespace Metaregistrar\EPP;
 
 class metaregSslDeleteResponse extends eppResponse {
 
-    function __construct() {
-        parent::__construct();
-    }
 }

--- a/Protocols/EPP/eppExtensions/ssl-1.0/eppResponses/metaregSslInfoResponse.php
+++ b/Protocols/EPP/eppExtensions/ssl-1.0/eppResponses/metaregSslInfoResponse.php
@@ -29,10 +29,6 @@ namespace Metaregistrar\EPP;
 
 class metaregSslInfoResponse extends eppResponse {
 
-    function __construct() {
-        parent::__construct();
-    }
-
     /**
      * @return null|string
      */

--- a/Protocols/EPP/eppExtensions/ssl-1.0/eppResponses/metaregSslReissueResponse.php
+++ b/Protocols/EPP/eppExtensions/ssl-1.0/eppResponses/metaregSslReissueResponse.php
@@ -29,7 +29,4 @@ namespace Metaregistrar\EPP;
 
 class metaregSslReissueResponse extends metaregSslRenewResponse  {
 
-    function __construct() {
-        parent::__construct();
-    }
 }

--- a/Protocols/EPP/eppExtensions/ssl-1.0/eppResponses/metaregSslRenewResponse.php
+++ b/Protocols/EPP/eppExtensions/ssl-1.0/eppResponses/metaregSslRenewResponse.php
@@ -29,10 +29,6 @@ namespace Metaregistrar\EPP;
 
 class metaregSslRenewResponse extends eppResponse  {
 
-    function __construct() {
-        parent::__construct();
-    }
-
     /**
      * @return null|string
      */

--- a/Protocols/EPP/eppExtensions/teleinfo/eppResponses/teleinfoEppPollResponse.php
+++ b/Protocols/EPP/eppExtensions/teleinfo/eppResponses/teleinfoEppPollResponse.php
@@ -2,9 +2,6 @@
 namespace Metaregistrar\EPP;
 
 class teleinfoEppPollResponse extends eppPollResponse {
-    public function    __construct() {
-        parent::__construct();
-    }
     public function getNVResult(string $type='req'){
         if (!in_array($type, ['req','ack'])){
             throw new eppException('Poll action type '.$type.' is invalid, only req or ack is allowed.');

--- a/Protocols/EPP/eppExtensions/teleinfo/eppResponses/teleinfoEppUpdateNameResponse.php
+++ b/Protocols/EPP/eppExtensions/teleinfo/eppResponses/teleinfoEppUpdateNameResponse.php
@@ -2,9 +2,6 @@
 namespace Metaregistrar\EPP;
 
 class teleinfoEppUpdateNameResponse extends eppResponse {
-    public function __construct(){
-        parent::__construct();
-    }
     public function __destruct(){
         parent::__destruct();
     }

--- a/Protocols/EPP/eppExtensions/verisign/eppResponses/verisignEppPollResponse.php
+++ b/Protocols/EPP/eppExtensions/verisign/eppResponses/verisignEppPollResponse.php
@@ -39,9 +39,6 @@ class verisignEppPollResponse extends eppPollResponse {
     const OBJECT_UNKNOWN = 'unknown';
     private $objectType = null;
     private $messageType = null;
-    public function __construct() {
-        parent::__construct();
-    }
 
     public function __destruct() {
         parent::__destruct();


### PR DESCRIPTION
Since commit [b891fb0](https://github.com/metaregistrar/php-epp-client/commit/b891fb0ba67a151053a8bbd16c10a814bc27b555#diff-718099e031563b7af34542b137c4954a8f9fd93034aca7eb759a30e578235d6dR91) the $originalrequest argument to the eppResponse constructor became required. This change broke all the existing classes that override the constructor without passing the now-required argument. This PR removes the constructors from classes that inherit the eppResponse class and had no additional logic other than calling the parent constructor. These constructors are redundant and only add fragility if a change is made to the eppResponse constructor again.