### PR TITLE
Add `furyEppException` class to `fury-2.1` extension

### DIFF
--- a/Protocols/EPP/eppExtensions/fury-2.1/eppExceptions/furyEppException.php
+++ b/Protocols/EPP/eppExtensions/fury-2.1/eppExceptions/furyEppException.php
@@ -1,0 +1,29 @@
+<?php
+namespace Metaregistrar\EPP;
+
+/**
+ * Class furyEppException
+ *
+ * CIRA Fury 2.1 errors carry a registry-specific <fury:ciraCode> inside the
+ * standard EPP <result><extValue> block, e.g.:
+ *
+ * <result code="2303">
+ *   <msg>Object does not exist</msg>
+ *   <extValue>
+ *     <value><fury:ciraCode>8010</fury:ciraCode></value>
+ *     <reason>Domain name does not exist</reason>
+ *   </extValue>
+ * </result>
+ *
+ * @package Metaregistrar\EPP
+ */
+class furyEppException extends eppException {
+
+    public function getCiraCode() {
+        return $this->getResponse()->queryPath('/epp:epp/epp:response/epp:result/epp:extValue/epp:value/fury:ciraCode');
+    }
+
+    public function getCiraReason() {
+        return $this->getResponse()->queryPath('/epp:epp/epp:response/epp:result/epp:extValue/epp:reason');
+    }
+}

--- a/Protocols/EPP/eppExtensions/fury-2.1/includes.php
+++ b/Protocols/EPP/eppExtensions/fury-2.1/includes.php
@@ -15,3 +15,6 @@ $this->addCommandResponse('Metaregistrar\EPP\furyUpdateContactRequest', 'Metareg
 
 include_once(dirname(__FILE__) . '/eppResponses/furyInfoDomainResponse.php');
 $this->addCommandResponse('Metaregistrar\EPP\eppInfoDomainRequest', 'Metaregistrar\EPP\furyInfoDomainResponse');
+
+include_once(dirname(__FILE__) . '/eppExceptions/furyEppException.php');
+$this->addException('Metaregistrar\EPP\furyEppException');


### PR DESCRIPTION
## What does it do?
Adds `furyEppException` class to `fury-2.1` extension.

## How to test
1. Enable the `fury-2.1` extension.
2. Send a request that causes an exception.
3. Verify that a `furyEppException` is returned and that the `getCiraCode()` and `getCiraReason()` methods return the expected values.
