### PR TITLE
Fix PHP 7.x compatibility

### DIFF
--- a/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppInfoDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/dnsbe-1.0/eppResponses/dnsbeEppInfoDomainResponse.php
@@ -91,14 +91,17 @@ class dnsbeEppInfoDomainResponse extends eppInfoDomainResponse
         $xpath = $this->xPath();
         $result = $xpath->query('/epp:epp/epp:response/epp:extension/dnsbe:ext/dnsbe:infData/dnsbe:domain/dnsbe:nameserversOverridden');
 
-        $nameserversOveridden = $result->item(0)?->nodeValue;
+        $node = $result->item(0);
+        $nameserversOveridden = $node !== null ? $node->nodeValue : null;
 
         // If the nameservers are not overridden, the domain is not awaiting verification.
         if (!$nameserversOveridden) {
             return false;
         }
 
-        $reason = $result->item(0)?->attributes?->item(0)?->nodeValue;
+        $attributes = $node !== null ? $node->attributes : null;
+        $attribute = $attributes !== null ? $attributes->item(0) : null;
+        $reason = $attribute !== null ? $attribute->nodeValue : null;
 
         return $nameserversOveridden === 'true' && $reason === 'Pending registrant verification';
     }

--- a/Protocols/EPP/eppExtensions/domain-ext-2.5/eppRequests/euridEppUpdateDomainRequest.php
+++ b/Protocols/EPP/eppExtensions/domain-ext-2.5/eppRequests/euridEppUpdateDomainRequest.php
@@ -43,6 +43,10 @@ use DOMElement;
 */
 class euridEppUpdateDomainRequest extends eppUpdateDomainRequest
 {
+    /**
+     * @param string|array|null $addnsgroup
+     * @param string|array|null $removensgroup
+     */
     public function __construct(
         $objectname,
         ?eppDomain $addinfo = null,
@@ -51,15 +55,19 @@ class euridEppUpdateDomainRequest extends eppUpdateDomainRequest
         bool $forcehostattr = true,
         bool $namespacesinroot = true,
         bool $usecdata = true,
-        string|array|null $addnsgroup = null,
-        string|array|null $removensgroup = null
+        $addnsgroup = null,
+        $removensgroup = null
     ) {
         parent::__construct($objectname, $addinfo, $removeinfo, $updateinfo, $forcehostattr, $namespacesinroot, $usecdata);
         $this->updateNameserverGroups($addnsgroup, $removensgroup);
         parent::addSessionId();
     }
 
-    private function updateNameserverGroups(string|array|null $addnsgroup = null, string|array|null $removensgroup = null): void
+    /**
+     * @param string|array|null $addnsgroup
+     * @param string|array|null $removensgroup
+     */
+    private function updateNameserverGroups($addnsgroup = null, $removensgroup = null): void
     {
         if ($addnsgroup === null && $removensgroup === null) {
             return;
@@ -79,7 +87,10 @@ class euridEppUpdateDomainRequest extends eppUpdateDomainRequest
         $this->getExtension()->appendChild($update);
     }
 
-    private function processNameservergroup(DOMElement $parent, string $action, string|array $nsgroup): void
+    /**
+     * @param string|array $nsgroup
+     */
+    private function processNameservergroup(DOMElement $parent, string $action, $nsgroup): void
     {
         if (is_array($nsgroup) && !empty($nsgroup)) {
             $element = $this->createElement($action);

--- a/Protocols/EPP/eppExtensions/fury-2.1/eppResponses/furyInfoDomainResponse.php
+++ b/Protocols/EPP/eppExtensions/fury-2.1/eppResponses/furyInfoDomainResponse.php
@@ -31,7 +31,10 @@ class furyInfoDomainResponse extends eppInfoDomainResponse {
 		return $result;
 	}
 
-	public function getFuryBundle(): null {
+	/**
+	 * @return null
+	 */
+	public function getFuryBundle() {
 		/**
 		 * This function was not implemented yet because we were not able to test it in the wild
 		 *

--- a/Protocols/EPP/eppExtensions/org-1.0/eppRequests/orgEppCheckRequest.php
+++ b/Protocols/EPP/eppExtensions/org-1.0/eppRequests/orgEppCheckRequest.php
@@ -24,7 +24,7 @@ class orgEppCheckRequest extends eppRequest {
 	 *
 	 * Check on or more reseller ID's to see if they are taken or free
 	 */
-	function __construct(string|array $orgid) {
+	function __construct($orgid) {
 		parent::__construct();
 		$command = $this->getCommand();
 		$check = $this->createElement('check');

--- a/Protocols/EPP/eppExtensions/org-1.0/eppRequests/orgEppCreateRequest.php
+++ b/Protocols/EPP/eppExtensions/org-1.0/eppRequests/orgEppCreateRequest.php
@@ -36,7 +36,8 @@ namespace Metaregistrar\EPP;
  */
 
 class orgEppCreateRequest extends eppCreateRequest {
-	private \DOMElement|false $createobject;
+	/** @var \DOMElement|false */
+	private $createobject;
 	CONST TYPE_RESELLER = 'reseller';
 
 	/**

--- a/Protocols/EPP/eppExtensions/org-1.0/eppRequests/orgEppUpdateRequest.php
+++ b/Protocols/EPP/eppExtensions/org-1.0/eppRequests/orgEppUpdateRequest.php
@@ -8,7 +8,8 @@ namespace Metaregistrar\EPP;
 
 
 class orgEppUpdateRequest extends eppRequest {
-	private \DOMElement|false $updateobject;
+	/** @var \DOMElement|false */
+	private $updateobject;
 
 	/**
 	 * @param string $handle

--- a/Protocols/EPP/eppResponses/eppResponse.php
+++ b/Protocols/EPP/eppResponses/eppResponse.php
@@ -91,7 +91,7 @@ class eppResponse extends \DOMDocument {
      */
     public $defaultnamespace;
 
-    public function __construct(eppRequest|null $originalrequest=null) {
+    public function __construct(?eppRequest $originalrequest = null) {
         parent::__construct();
         $this->formatOutput = true;
         $this->originalrequest = $originalrequest;


### PR DESCRIPTION
Closes #457

The project's composer.json still allows PHP 7.1, which means older projects depending on this library may install version 1.0.16 and run into broken builds or runtime syntax errors.

This PR fixes PHP 7.x compatibility.